### PR TITLE
feat: useHead accepts more types of argument

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,27 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: yarn
+      - run: npm run test --if-present

--- a/README.md
+++ b/README.md
@@ -89,14 +89,14 @@ Create the head manager instance.
 
 ```ts
 interface HeadObject {
-  title?: string
-  base?: HeadAttrs
-  meta?: HeadAttrs[]
-  link?: HeadAttrs[]
-  style?: HeadAttrs[]
-  script?: HeadAttrs[]
-  htmlAttrs?: HeadAttrs
-  bodyAttrs?: HeadAttrs
+  title?: MaybeRef<string>
+  meta?: MaybeRef<HeadAttrs[]>
+  link?: MaybeRef<HeadAttrs[]>
+  base?: MaybeRef<HeadAttrs>
+  style?: MaybeRef<HeadAttrs[]>
+  script?: MaybeRef<HeadAttrs[]>
+  htmlAttrs?: MaybeRef<HeadAttrs>
+  bodyAttrs?: MaybeRef<HeadAttrs>
 }
 
 interface HeadAttrs {

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ const finalHTML = `
 
 Create the head manager instance.
 
-### `useHead(() => HeadObject)`
+### `useHead(head: HeadObject | Ref<HeadObject> | (() => HeadObject))`
 
 ```ts
 interface HeadObject {
@@ -133,6 +133,18 @@ useHead(() => ({
     },
   ],
 }))
+```
+
+`useHead` also takes reactive object or ref as the argument, for example:
+
+```ts
+const head = reactive({ title: 'Website Title' })
+useHead(head)
+```
+
+```ts
+const title = ref('Website Title')
+useHead({ title })
 ```
 
 ### `renderHeadToString(head: Head)`

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ import { useHead } from '@vueuse/head'
 
 export default defineComponent({
   setup() {
-    useHead(() => ({
+    useHead({
       title: `Website title`,
       meta: [
         {
@@ -47,7 +47,7 @@ export default defineComponent({
           content: `Website description`,
         },
       ],
-    }))
+    })
   },
 })
 </script>
@@ -107,7 +107,7 @@ interface HeadAttrs {
 For `meta` tags, we use `name` and `property` to prevent duplicated tags, you can instead use the `key` attribute if the same `name` or `property` is allowed:
 
 ```ts
-useHead(() => ({
+useHead({
   meta: [
     {
       property: 'og:locale:alternate',
@@ -120,19 +120,19 @@ useHead(() => ({
       key: 'en',
     },
   ],
-}))
+})
 ```
 
 To set the `textContent` of an element, use the `children` attribute:
 
 ```ts
-useHead(() => ({
+useHead({
   style: [
     {
       children: `body {color: red}`,
     },
   ],
-}))
+})
 ```
 
 `useHead` also takes reactive object or ref as the argument, for example:

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import { stringifyAttrs } from './stringify-attrs'
 export type HeadAttrs = { [k: string]: any }
 
 export type HeadObject = {
-  title?: string
+  title?: string | Ref<string>
   meta?: HeadAttrs[]
   link?: HeadAttrs[]
   base?: HeadAttrs


### PR DESCRIPTION
This makes `useHead` more flexible, resolves #4 

## Plain

```js
useHead({
	title: 'FooBar'
})
```

## Function

```js
useHead(() => ({
	title: 'FooBar'
}))
```

## Ref / Computed Ref

```js
const headObject = ref({
	title: 'FooBar'
})

useHead(headObject)

headObject.title = 'BarFoo'
```

```js
const headObject = computed(() => {
	title: 'FooBar'
})

useHead(headObject)
```