### PR TITLE
fix: ignore unknown props in headObject

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,10 +82,24 @@ const injectHead = () => {
   return head
 }
 
+const acceptFields: Array<keyof HeadObject> = [
+  'title',
+  'meta',
+  'link',
+  'base',
+  'style',
+  'script',
+  'htmlAttrs',
+  'bodyAttrs',
+]
+
 const headObjToTags = (obj: HeadObjectPlain) => {
   const tags: HeadTag[] = []
 
   for (const key of Object.keys(obj) as Array<keyof HeadObjectPlain>) {
+    if (!acceptFields.includes(key)) {
+      continue
+    }
     if (key === 'title') {
       tags.push({ tag: key, props: { children: obj[key] } })
     } else if (key === 'base') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,14 +97,11 @@ const headObjToTags = (obj: HeadObjectPlain) => {
   const tags: HeadTag[] = []
 
   for (const key of Object.keys(obj) as Array<keyof HeadObjectPlain>) {
-    if (!acceptFields.includes(key)) {
-      continue
-    }
     if (key === 'title') {
       tags.push({ tag: key, props: { children: obj[key] } })
     } else if (key === 'base') {
       tags.push({ tag: key, props: { key: 'default', ...obj[key] } })
-    } else {
+    } else if (acceptFields.includes(key)) {
       const value = obj[key]
       if (Array.isArray(value)) {
         value.forEach((item) => {


### PR DESCRIPTION
It's common to pass frontmatter or other objects that may have some extra properties, which will lead error for `useHead`. 

```js
useHead({
  title: 'foo',
  bar: 'bala' // error!
})
```