### PR TITLE
fix: ignores data-head-attrs attribute when empty

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -138,7 +138,11 @@ const setAttrs = (el: Element, attrs: HeadAttrs) => {
     }
   }
 
-  el.setAttribute(HEAD_ATTRS_KEY, keys.join(','))
+  if (keys.length) {
+    el.setAttribute(HEAD_ATTRS_KEY, keys.join(','))
+  } else {
+    el.removeAttribute(HEAD_ATTRS_KEY)
+  }
 }
 
 const insertTags = (tags: HeadTag[], document = window.document) => {


### PR DESCRIPTION
| <img width="267" alt="Screen Shot 2021-01-23 at 01 15 10" src="https://user-images.githubusercontent.com/1490347/105568569-3e8e2280-5d19-11eb-9b01-270e011d41a1.png"> | <img width="270" alt="Screen Shot 2021-01-23 at 01 21 53" src="https://user-images.githubusercontent.com/1490347/105568617-90cf4380-5d19-11eb-97ab-acedc12722aa.png"> |
|---|---|
