### PR TITLE
feat: replace meta tags if they already exist (#26)

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Document</title>
+    <meta name="description" content="this should be removed" />
   </head>
   <body>
     <div id="app"></div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -201,23 +201,18 @@ const insertTags = (tags: HeadTag[], document = window.document) => {
       continue
     }
 
-    // Remove tags with the same key
+    // Remove uncontrolled meta tags with the same key
     if (tag.tag === 'meta') {
-      let elementList: Element[] = []
+      const key = getTagKey(tag.props)
 
-      if (tag.props.name) {
-        elementList = [
-          ...head.querySelectorAll(`meta[name="${tag.props.name}"]`),
+      if (key) {
+        const elementList = [
+          ...head.querySelectorAll(`meta[${key.name}="${key.value}"]`),
         ]
-      } else if (tag.props.property) {
-        elementList = [
-          ...head.querySelectorAll(`meta[property="${tag.props.property}"]`),
-        ]
-      }
-
-      for (const el of elementList) {
-        if (!oldElements.includes(el)) {
-          oldElements.push(el)
+        for (const el of elementList) {
+          if (!oldElements.includes(el)) {
+            oldElements.push(el)
+          }
         }
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,7 +164,7 @@ const insertTags = (tags: HeadTag[], document = window.document) => {
   const headCount = headCountEl
     ? Number(headCountEl.getAttribute('content'))
     : 0
-  const oldElements: (ChildNode | Element)[] = []
+  const oldElements: Element[] = []
   if (headCountEl) {
     for (
       let i = 0, j = headCountEl.previousElementSibling;

--- a/src/index.ts
+++ b/src/index.ts
@@ -200,6 +200,28 @@ const insertTags = (tags: HeadTag[], document = window.document) => {
       Object.assign(bodyAttrs, tag.props)
       continue
     }
+
+    // Remove tags with the same key
+    if (tag.tag === 'meta') {
+      let elementList: Element[] = []
+
+      if (tag.props.name) {
+        elementList = [
+          ...head.querySelectorAll(`meta[name="${tag.props.name}"]`),
+        ]
+      } else if (tag.props.property) {
+        elementList = [
+          ...head.querySelectorAll(`meta[property="${tag.props.property}"]`),
+        ]
+      }
+
+      for (const el of elementList) {
+        if (!oldElements.includes(el)) {
+          oldElements.push(el)
+        }
+      }
+    }
+
     newElements.push(createElement(tag.tag, tag.props, document))
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,7 +164,7 @@ const insertTags = (tags: HeadTag[], document = window.document) => {
   const headCount = headCountEl
     ? Number(headCountEl.getAttribute('content'))
     : 0
-  const oldElements: Element[] = []
+  const oldElements: (ChildNode | Element)[] = []
   if (headCountEl) {
     for (
       let i = 0, j = headCountEl.previousElementSibling;
@@ -221,6 +221,10 @@ const insertTags = (tags: HeadTag[], document = window.document) => {
   }
 
   oldElements.forEach((el) => {
+    // Remove the next text node first, almost certainly a line break
+    if (el.nextSibling && el.nextSibling.nodeType === Node.TEXT_NODE) {
+      el.nextSibling.remove()
+    }
     el.remove()
   })
   if (title !== undefined) {

--- a/tests/test.tsx
+++ b/tests/test.tsx
@@ -88,7 +88,7 @@ test('browser', async (t) => {
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>count: 0</title>
-  <base href="/"><style>body {background: red}</style><meta name="description" content="desc 2"><meta property="og:locale:alternate" content="fr"><meta property="og:locale:alternate" content="zh"><meta name="head:count" content="5">`,
+    <base href="/"><style>body {background: red}</style><meta name="description" content="desc 2"><meta property="og:locale:alternate" content="fr"><meta property="og:locale:alternate" content="zh"><meta name="head:count" content="5">`,
   )
 
   await page.click('button.counter')


### PR DESCRIPTION
This PR should fix #26.

The only problem I got was `browser` test failed when I added some meta tags to html page. That's why I keep original html in examples folder.

Meta tags have been added:
```html
<meta name="description" content="test" />
<meta property="og:locale:alternate" content="ru" />
```

After the plugin running I got the following difference with blank lines and have no idea how to avoid of it. But from my point of view keeping these lines in test even worse idea.
<img width="925" alt="Screenshot 2021-05-19 at 23 34 44" src="https://user-images.githubusercontent.com/119337/118880714-d6340400-b8fa-11eb-99ef-1f01764ee085.png">
