### PR TITLE
feat: dedupe scripts with key

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -201,13 +201,13 @@ const insertTags = (tags: HeadTag[], document = window.document) => {
       continue
     }
 
-    // Remove uncontrolled meta tags with the same key
-    if (tag.tag === 'meta') {
+    // Remove uncontrolled meta and script tags with the same key
+    if (tag.tag === 'meta' || tag.tag === 'script') {
       const key = getTagKey(tag.props)
 
       if (key) {
         const elementList = [
-          ...head.querySelectorAll(`meta[${key.name}="${key.value}"]`),
+          ...head.querySelectorAll(`${tag.tag}[${key.name}="${key.value}"]`),
         ]
         for (const el of elementList) {
           if (!oldElements.includes(el)) {
@@ -257,7 +257,11 @@ export const createHead = () => {
       allHeadObjs.forEach((objs) => {
         const tags = headObjToTags(objs.value)
         tags.forEach((tag) => {
-          if (tag.tag === 'meta' || tag.tag === 'base') {
+          if (
+            tag.tag === 'meta' ||
+            tag.tag === 'base' ||
+            tag.tag === 'script'
+          ) {
             // Remove tags with the same key
             const key = getTagKey(tag.props)
             if (key) {

--- a/tests/test.tsx
+++ b/tests/test.tsx
@@ -174,3 +174,32 @@ test('children', async (t) => {
     `<script>console.log('hi')</script><meta name="head:count" content="1">`,
   )
 })
+
+test('script key', async (t) => {
+  const head = createHead()
+  const app = createSSRApp({
+    setup() {
+      useHead({
+        script: [
+          {
+            key: 'my-script',
+            children: `console.log('A')`,
+          },
+          {
+            key: 'my-script',
+            children: `console.log('B')`,
+          },
+        ],
+      })
+      return () => <div>hi</div>
+    },
+  })
+  app.use(head)
+  await renderToString(app)
+
+  const headResult = renderHeadToString(head)
+  t.is(
+    headResult.headTags,
+    `<script>console.log('B')</script><meta name="head:count" content="1">`,
+  )
+})


### PR DESCRIPTION
Adds unique `key` support to `script` tags.

Other possibilities:

- generalize to a whitelist
- add support for id
- add support for id and/or key to all tags