### PR TITLE
fix getTagKey for HTML element

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,7 @@ const getTagKey = (
     const value =
       // Probably an HTML Element
       typeof props.getAttribute === 'function'
-        ? props.getAttribute(n)
+        ? (props.hasAttribute(n) ? props.getAttribute(n) : undefined)
         : props[n]
     if (value !== undefined) {
       return { name: n, value: value }


### PR DESCRIPTION
getAttribute returns null if attribute not exists, so it will always check only for key attribute and returns.

<img width="228" alt="image" src="https://user-images.githubusercontent.com/11233730/147216526-af5b3d9e-24a2-41b8-841e-0f1b93966de1.png">
