### PR TITLE
feat: allow tags insertion before `</body>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ import { renderHeadToString } from '@vueuse/head'
 const appHTML = await renderToString(yourVueApp)
 
 // `head` is created from `createHead()`
-const { headTags, htmlAttrs, bodyAttrs } = renderHeadToString(head)
+const { headTags, htmlAttrs, bodyAttrs, bodyTags } = renderHeadToString(head)
 
 const finalHTML = `
 <html${htmlAttrs}>
@@ -81,6 +81,7 @@ const finalHTML = `
 
   <body${bodyAttrs}>
     <div id="app">${appHTML}</div>
+    ${bodyTags}
   </body>
 
 </html>
@@ -126,6 +127,19 @@ useHead({
       property: 'og:locale:alternate',
       content: 'en',
       key: 'en',
+    },
+  ],
+})
+```
+
+To render tags at the end of the `<body>`, set `body: true` in a HeadAttrs Object.
+
+```ts
+useHead({
+  script: [
+    {
+      children: `console.log('Hello world!')`,
+      body: true
     },
   ],
 })
@@ -180,13 +194,15 @@ Note that you need to use `<html>` and `<body>` to set `htmlAttrs` and `bodyAttr
 - Returns: `HTMLResult`
 
 ```ts
-interface HTMLResult {
+export interface HTMLResult {
   // Tags in `<head>`
   readonly headTags: string
   // Attributes for `<html>`
   readonly htmlAttrs: string
   // Attributes for `<body>`
   readonly bodyAttrs: string
+  // Tags in `<body>`
+  readonly bodyTags: string
 }
 ```
 

--- a/example/app.tsx
+++ b/example/app.tsx
@@ -61,6 +61,12 @@ export const createApp = () => {
             key: 'zh',
           },
         ],
+        script: [
+          {
+            children: `console.log('hi')`,
+            body: true
+          },
+        ],
       })
       return () => (
         <div>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,3 +4,5 @@ export const HEAD_COUNT_KEY = `head:count`
 export const HEAD_ATTRS_KEY = `data-head-attrs`
 
 export const SELF_CLOSING_TAGS = ['meta', 'link', 'base']
+
+export const BODY_TAG_ATTR_NAME = `data-meta-body`

--- a/src/create-element.ts
+++ b/src/create-element.ts
@@ -17,7 +17,7 @@ export const createElement = (
       if (key === 'key' || value === false) {
         continue
       }
-  
+
       if (key === 'children') {
         el.textContent = value
       } else {

--- a/src/create-element.ts
+++ b/src/create-element.ts
@@ -8,9 +8,9 @@ export const createElement = (
   const el = document.createElement(tag)
 
   for (const key of Object.keys(attrs)) {
-    if(key === "body" && attrs.body === true){
+    if (key === 'body' && attrs.body === true) {
       // set meta-body attribute to add the tag before </body>
-      el.setAttribute(BODY_TAG_ATTR_NAME, "true")
+      el.setAttribute(BODY_TAG_ATTR_NAME, 'true')
     } else {
       let value = attrs[key]
 

--- a/src/create-element.ts
+++ b/src/create-element.ts
@@ -1,3 +1,5 @@
+import { BODY_TAG_ATTR_NAME } from "./constants"
+
 export const createElement = (
   tag: string,
   attrs: { [k: string]: any },
@@ -6,16 +8,21 @@ export const createElement = (
   const el = document.createElement(tag)
 
   for (const key of Object.keys(attrs)) {
-    let value = attrs[key]
-
-    if (key === 'key' || value === false) {
-      continue
-    }
-
-    if (key === 'children') {
-      el.textContent = value
+    if(key === "body" && attrs.body === true){
+      // set meta-body attribute to add the tag before </body>
+      el.setAttribute(BODY_TAG_ATTR_NAME, "true")
     } else {
-      el.setAttribute(key, value)
+      let value = attrs[key]
+
+      if (key === 'key' || value === false) {
+        continue
+      }
+  
+      if (key === 'children') {
+        el.textContent = value
+      } else {
+        el.setAttribute(key, value)
+      }
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,7 +133,6 @@ const headObjToTags = (obj: HeadObjectPlain) => {
     }
   }
 
-
   return tags
 }
 
@@ -182,11 +181,11 @@ const updateElements = (
     ? Number(headCountEl.getAttribute('content'))
     : 0
   const oldHeadElements: Element[] = []
-  const oldBodyElements: Element[] = [];
+  const oldBodyElements: Element[] = []
 
-  if(bodyMetaElements){
-    for(let i = 0; i < bodyMetaElements.length; i++ ){
-      if(bodyMetaElements[i] && bodyMetaElements[i].tagName?.toLowerCase() === type){
+  if (bodyMetaElements) {
+    for (let i = 0; i < bodyMetaElements.length; i++ ) {
+      if (bodyMetaElements[i] && bodyMetaElements[i].tagName?.toLowerCase() === type) {
         oldBodyElements.push(bodyMetaElements[i])
       }
     }
@@ -226,9 +225,9 @@ const updateElements = (
   oldBodyElements.forEach((t) => t.parentNode?.removeChild(t))
   oldHeadElements.forEach((t) => t.parentNode?.removeChild(t))
   newElements.forEach((t) => {
-    if(t.body === true) {
+    if (t.body === true) {
       body.insertAdjacentElement('beforeend', t.element)
-    }else {
+    } else {
       head.insertBefore(t.element, headCountEl)
     }
   })
@@ -360,18 +359,18 @@ export const useHead = (obj: MaybeRef<HeadObject>) => {
 }
 
 const tagToString = (tag: HeadTag) => {
-  let isBodyTag = false;
-  if(tag.props.body){
-    isBodyTag = true;
+  let isBodyTag = false
+  if (tag.props.body) {
+    isBodyTag = true
     // avoid rendering body attr
     delete tag.props.body
   }
   let attrs = stringifyAttrs(tag.props)
   if (SELF_CLOSING_TAGS.includes(tag.tag)) {
-    return `<${tag.tag}${attrs}${isBodyTag ? ' ' + BODY_TAG_ATTR_NAME: ''}>`
+    return `<${tag.tag}${attrs}${isBodyTag ? ' ' + BODY_TAG_ATTR_NAME : ''}>`
   }
 
-  return `<${tag.tag}${attrs}${isBodyTag ? ' ' + BODY_TAG_ATTR_NAME: ''}>${tag.props.children || ''}</${tag.tag}>`
+  return `<${tag.tag}${attrs}${isBodyTag ? ' ' + BODY_TAG_ATTR_NAME : ''}>${tag.props.children || ''}</${tag.tag}>`
 }
 
 export const renderHeadToString = (head: HeadClient): HTMLResult => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -184,7 +184,7 @@ const updateElements = (
   const oldBodyElements: Element[] = []
 
   if (bodyMetaElements) {
-    for (let i = 0; i < bodyMetaElements.length; i++ ) {
+    for (let i = 0; i < bodyMetaElements.length; i++) {
       if (bodyMetaElements[i] && bodyMetaElements[i].tagName?.toLowerCase() === type) {
         oldBodyElements.push(bodyMetaElements[i])
       }

--- a/tests/test.tsx
+++ b/tests/test.tsx
@@ -191,3 +191,12 @@ test('script key', async (t) => {
     `<script>console.log('B')</script><meta name="head:count" content="1">`,
   )
 })
+
+test('body script', async (t) => {
+  const page = await t.context.browser.newPage()
+  await page.goto(`http://localhost:3000`)
+
+  const script = await page.$('[data-meta-body]')
+  const scriptHtml = await script.innerHTML()
+  t.is(scriptHtml, `console.log('hi')`)
+})


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolve #53 , linked to https://github.com/nuxt/framework/issues/5014 , linked to https://github.com/nuxt/framework/issues/3130

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Allow adding tags before the end of `</body>` . For now, there is no restriction on the tag type.