### PR TITLE
Fix setAttrs runs before head is ready

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -283,6 +283,7 @@ export const createHead = () => {
       let title: string | undefined
       let htmlAttrs: HeadAttrs = {}
       let bodyAttrs: HeadAttrs = {}
+      let setHeadAttrs = false
 
       const actualTags: Record<string, HeadTag[]> = {}
 
@@ -293,6 +294,7 @@ export const createHead = () => {
         }
         if (tag.tag === 'htmlAttrs') {
           Object.assign(htmlAttrs, tag.props)
+          setHeadAttrs = true
           continue
         }
         if (tag.tag === 'bodyAttrs') {
@@ -307,7 +309,11 @@ export const createHead = () => {
       if (title !== undefined) {
         document.title = title
       }
-      setAttrs(document.documentElement, htmlAttrs)
+
+      if (setHeadAttrs) {
+        setAttrs(document.documentElement, htmlAttrs)
+      }
+
       setAttrs(document.body, bodyAttrs)
       const tags = new Set([...Object.keys(actualTags), ...previousTags])
       for (const tag of tags) {


### PR DESCRIPTION
### :link: Linked issue

resolve #75 

### :question:  Type of change

- [ ]   :book:  Documentation (updates to the documentation or readme)
- [x]   :lady_beetle:  Bug fix (a non-breaking change that fixes an issue)
- [ ]   :ok_hand:  Enhancement (improving an existing functionality like performance)
- [ ]   :sparkles:  New feature (a non-breaking change that adds functionality)
- [ ]   :warning:  Breaking change (fix or feature that would cause existing functionality to change)

### :books:  Description

Nuxt3 runs the `updateDOM` function directly before the head has htmlAttrs, and this is causing to clear existing attributes in the head; this happened during hydration