### PR TITLE
fix: deduplicated body tags

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -221,6 +221,13 @@ const updateElements = (
         return false
       }
     }
+    for(let i = 0; i < oldBodyElements.length; i++) {
+      const oldEl = oldBodyElements[i]
+      if (isEqualNode(oldEl, newEl.element)) {
+        oldBodyElements.splice(i, 1)
+        return false
+      }
+    }
     return true
   })
 
@@ -369,10 +376,10 @@ const tagToString = (tag: HeadTag) => {
   }
   let attrs = stringifyAttrs(tag.props)
   if (SELF_CLOSING_TAGS.includes(tag.tag)) {
-    return `<${tag.tag}${attrs}${isBodyTag ? ' ' + BODY_TAG_ATTR_NAME : ''}>`
+    return `<${tag.tag}${attrs}${isBodyTag ? ' ' + ` ${BODY_TAG_ATTR_NAME}="true"` : ''}>`
   }
 
-  return `<${tag.tag}${attrs}${isBodyTag ? ' ' + BODY_TAG_ATTR_NAME : ''}>${tag.props.children || ''}</${tag.tag}>`
+  return `<${tag.tag}${attrs}${isBodyTag ? ` ${BODY_TAG_ATTR_NAME}="true"` : ''}>${tag.props.children || ''}</${tag.tag}>`
 }
 
 export const renderHeadToString = (head: HeadClient): HTMLResult => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
- fix https://github.com/vueuse/head/pull/67
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Hi @antfu , the PR https://github.com/vueuse/head/pull/67 has an issue where on updated meta, the body tags where removed then replaced before the `</body>`, this cause the script to be loaded twice. Also `="true"` on the body tag was missing for the meta-body-tag attribute at `tagToString()` , causing a deduplicated script on load.

- fix body tags (unexpected deduplicated scripts)
  - fix body tags being removed then replaced on updateDOM
  - fix deduplicated body tags on ssr

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

