### PR TITLE
fix(package): allow vue 2.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,6 @@
     "vue-router": "^4.1.2"
   },
   "peerDependencies": {
-    "vue": ">=3"
+    "vue": ">=2.7 || >=3"
   }
 }


### PR DESCRIPTION
According to my experience, this package can be used with [Vue 2.7](https://blog.vuejs.org/posts/vue-2-7-naruto.html) as well. The only limiting factor is that pnpm throws an "unmet peer dependency error" because the `package.json` currently only allows v3.