### PR TITLE
fix(types): export head schemas

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,8 @@ import { stringifyAttrs } from "./stringify-attrs"
 import { isEqualNode } from "./utils"
 import type { HeadObjectPlain, HeadObject, TagKeys } from "./types"
 
+export * from './types'
+
 type MaybeRef<T> = T | Ref<T>
 
 export type HeadAttrs = { [k: string]: any }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import type { Head as PlainHead, ReactiveHead } from "@zhead/schema-vue"
 
-interface HandlesDuplicates {
+export interface HandlesDuplicates {
   /**
    * By default, tags which share the same unique key `name, `property` are de-duped. To allow duplicates
    * to be made you can provide a unique key for each entry.
@@ -8,21 +8,21 @@ interface HandlesDuplicates {
   key?: string
 }
 
-interface RendersToBody {
+export interface RendersToBody {
   /**
    * Render tag at the end of the <body>.
    */
   body?: boolean
 }
 
-interface RendersInnerContent {
+export interface RendersInnerContent {
   /**
    * Sets the textContent of an element.
    */
   children?: string
 }
 
-interface HeadAugmentations {
+export interface HeadAugmentations {
   base: HandlesDuplicates & { body?: never; children?: never }
   link: RendersToBody & { key?: never; children?: never }
   meta: HandlesDuplicates & { children?: never; body?: never }


### PR DESCRIPTION
Related to https://github.com/vueuse/head/pull/85

I forgot to include exporting of the types, this is useful for frameworks with custom implementations of the useHead schema (nuxt). 

