### PR TITLE
feat: DOM update resumability API 

### DIFF
--- a/examples/nuxt3/app.vue
+++ b/examples/nuxt3/app.vue
@@ -1,8 +1,21 @@
 <script setup lang="ts">
 import { useHead } from "#head"
 
+// useHead({
+//   script: [
+//     {
+//       async: true,
+//       src: 'https://utteranc.es/client.js',
+//       repo: 'codybontecou/blog',
+//       theme: 'github-dark',
+//       crossorigin: 'anonymous',
+//       'issue-term': computed(() => useRoute().path),
+//     },
+//   ],
+// })
+
 useHead({
-  title: "Title",
+  titleTemplate: (title) => `${title} | Title Site`,
 })
 </script>
 <template>

--- a/examples/nuxt3/app.vue
+++ b/examples/nuxt3/app.vue
@@ -1,20 +1,8 @@
 <script setup lang="ts">
 import { useHead } from "#head"
 
-// useHead({
-//   script: [
-//     {
-//       async: true,
-//       src: 'https://utteranc.es/client.js',
-//       repo: 'codybontecou/blog',
-//       theme: 'github-dark',
-//       crossorigin: 'anonymous',
-//       'issue-term': computed(() => useRoute().path),
-//     },
-//   ],
-// })
-
 useHead({
+  title: "Title",
   titleTemplate: (title) => `${title} | Title Site`,
 })
 </script>

--- a/examples/nuxt3/components/ModifyTitle.vue
+++ b/examples/nuxt3/components/ModifyTitle.vue
@@ -1,0 +1,13 @@
+<script lang="ts" setup>
+const props = defineProps<{
+  title: string
+}>()
+await new Promise((resolve) => setTimeout(resolve, 1000))
+
+useHead({
+  title: computed(() => props.title),
+})
+</script>
+<template>
+  <div>final title test</div>
+</template>

--- a/examples/nuxt3/nuxt.config.ts
+++ b/examples/nuxt3/nuxt.config.ts
@@ -1,5 +1,7 @@
 import { defineNuxtConfig } from "nuxt/config"
 import { fileURLToPath } from "url"
+import { addPlugin } from "@nuxt/kit"
+import { resolve } from "pathe"
 
 const runtimeDir = fileURLToPath(new URL("./runtime", import.meta.url))
 const rootDir = fileURLToPath(new URL("../../", import.meta.url))
@@ -9,12 +11,32 @@ export default defineNuxtConfig({
   alias: {
     "@vueuse/head": `${rootDir}/src`,
   },
+  app: {
+    head: {
+      title: "default title",
+    },
+  },
   workspaceDir: rootDir,
   hooks: {
+    "modules:before": async ({ nuxt }) => {
+      const newModules = nuxt.options._modules
+      // remove the nuxt meta (head) module
+      for (const k in newModules) {
+        if (typeof newModules[k] === "function") {
+          if ((await newModules[k].getMeta()).name === "meta") {
+            // we can't use an undefined key so use a duplicate
+            newModules[k] = "@nuxt/telemetry"
+          }
+        }
+      }
+      nuxt.options._modules = newModules
+    },
     "modules:done"({ nuxt }) {
       // Replace #head alias
-      nuxt.options.alias["#_head"] = nuxt.options.alias["#head"]
       nuxt.options.alias["#head"] = runtimeDir
+
+      addPlugin({ src: resolve(runtimeDir, "plugin") }, { append: true })
+
       nuxt.options.build.transpile.push(runtimeDir)
     },
   },

--- a/examples/nuxt3/pages/index.vue
+++ b/examples/nuxt3/pages/index.vue
@@ -1,11 +1,11 @@
 <script lang="ts" setup>
+import { useHead } from "#head"
+
 const page = ref({
   title: "Home",
   description: "Home page description",
   image: "https://nuxtjs.org/meta_400.png",
 })
-
-const changeBg = ref(true)
 
 useHead({
   title: computed(() => `${page.value.title} | Nuxt`),
@@ -19,26 +19,11 @@ useHead({
       content: computed(() => page.value.image),
     },
   ],
-  style: [
-    computed(() => {
-      console.log(changeBg)
-      return {
-        children: changeBg.value
-          ? "body { background-color: antiquewhite; }"
-          : "",
-      }
-    }),
-  ],
 })
-
-const toggleBg = () => {
-  changeBg.value = !changeBg.value
-}
 </script>
 <template>
   <div>
     <h1>Index</h1>
-    <button @click="toggleBg">switch bg</button>
     <nuxt-link to="/second">second page</nuxt-link>
   </div>
 </template>

--- a/examples/nuxt3/pages/index.vue
+++ b/examples/nuxt3/pages/index.vue
@@ -1,11 +1,11 @@
 <script lang="ts" setup>
-import { useHead } from "#head"
-
 const page = ref({
   title: "Home",
   description: "Home page description",
   image: "https://nuxtjs.org/meta_400.png",
 })
+
+const changeBg = ref(true)
 
 useHead({
   title: computed(() => `${page.value.title} | Nuxt`),
@@ -19,10 +19,26 @@ useHead({
       content: computed(() => page.value.image),
     },
   ],
+  style: [
+    computed(() => {
+      console.log(changeBg)
+      return {
+        children: changeBg.value
+          ? "body { background-color: antiquewhite; }"
+          : "",
+      }
+    }),
+  ],
 })
+
+const toggleBg = () => {
+  changeBg.value = !changeBg.value
+}
 </script>
 <template>
   <div>
     <h1>Index</h1>
+    <button @click="toggleBg">switch bg</button>
+    <nuxt-link to="/second">second page</nuxt-link>
   </div>
 </template>

--- a/examples/nuxt3/pages/second.vue
+++ b/examples/nuxt3/pages/second.vue
@@ -1,0 +1,33 @@
+<script lang="ts" setup>
+await new Promise((resolve) => setTimeout(resolve, 1000))
+
+const title = ref("Intermediately title with 1s delay")
+
+useHead({
+  title,
+  style: [
+    // this is an example of the side effects of this rendering strategy
+    // this style won't be hydrated until ModifyTitle has been mounted
+    {
+      children: `h2 { color: ${process.server ? "red" : "lime"}; }`,
+    },
+  ],
+})
+
+const changeTitle = () => {
+  title.value = "Intermediately title updated"
+}
+
+const finalTitle = computed(() => {
+  return title.value.replace("Intermediately", "Final")
+})
+</script>
+<template>
+  <div>
+    <h2>second page</h2>
+    <p>has a 1 second delay on rendering</p>
+    <ModifyTitle :title="finalTitle" />
+    <button @click="changeTitle">change title</button>
+    <nuxt-link to="/">first page</nuxt-link>
+  </div>
+</template>

--- a/examples/nuxt3/pages/second.vue
+++ b/examples/nuxt3/pages/second.vue
@@ -5,11 +5,14 @@ const title = ref("Intermediately title with 1s delay")
 
 useHead({
   title,
+  bodyAttrs: {
+    class: 'new-bg'
+  },
   style: [
     // this is an example of the side effects of this rendering strategy
-    // this style won't be hydrated until ModifyTitle has been mounted
+    // this style won't be hydrated at all
     {
-      children: `h2 { color: ${process.server ? "red" : "lime"}; }`,
+      children: `.new-bg { background-color: lemonchiffon; } h2 { color: ${process.server ? "red" : "lime"}; }`,
     },
   ],
 })

--- a/examples/nuxt3/pages/second.vue
+++ b/examples/nuxt3/pages/second.vue
@@ -6,13 +6,15 @@ const title = ref("Intermediately title with 1s delay")
 useHead({
   title,
   bodyAttrs: {
-    class: 'new-bg'
+    class: "new-bg",
   },
   style: [
     // this is an example of the side effects of this rendering strategy
     // this style won't be hydrated at all
     {
-      children: `.new-bg { background-color: lemonchiffon; } h2 { color: ${process.server ? "red" : "lime"}; }`,
+      children: `.new-bg { background-color: lemonchiffon; } h2 { color: ${
+        process.server ? "red" : "lime"
+      }; }`,
     },
   ],
 })

--- a/examples/nuxt3/runtime/index.ts
+++ b/examples/nuxt3/runtime/index.ts
@@ -1,9 +1,12 @@
-import { useHead as _useHead } from "#_head"
-import { HeadObject } from "@vueuse/head"
-import type { MetaObject as _MetaObject } from "#_head"
+import type { HeadObject } from "@vueuse/head"
+import { useNuxtApp } from "#app"
 
 export type MetaObject = HeadObject
 
-export function useHead(meta: HeadObject) {
-  _useHead(meta as _MetaObject)
+export function useHead(meta: MetaObject) {
+  useNuxtApp()._useHead(meta)
+}
+
+export function useMeta(meta: MetaObject) {
+  useHead(meta)
 }

--- a/examples/nuxt3/runtime/plugin.ts
+++ b/examples/nuxt3/runtime/plugin.ts
@@ -1,0 +1,96 @@
+import { createHead, renderHeadToString } from "@vueuse/head"
+import {
+  computed,
+  ref,
+  watchEffect,
+  onBeforeUnmount,
+  getCurrentInstance,
+  ComputedGetter,
+} from "vue"
+import defu from "defu"
+import type { MetaObject } from "."
+import { defineNuxtPlugin } from "#app"
+import { watch } from "#imports"
+
+export default defineNuxtPlugin((nuxtApp) => {
+  const head = createHead()
+
+  nuxtApp.vueApp.use(head)
+
+  const headReady = ref(false)
+  nuxtApp.hooks.hookOnce("app:mounted", () => {
+    if (head._ssrHydrateFromNodeId === false) {
+      watchEffect(() => {
+        head.updateDOM()
+      })
+    }
+    headReady.value = true
+  })
+
+  nuxtApp._useHead = (_meta: MetaObject | ComputedGetter<MetaObject>) => {
+    const meta = ref<MetaObject>(_meta)
+    const headObj = computed(() => {
+      const overrides: MetaObject = { meta: [] }
+      if (meta.value.charset) {
+        overrides.meta!.push({ key: "charset", charset: meta.value.charset })
+      }
+      if (meta.value.viewport) {
+        overrides.meta!.push({ name: "viewport", content: meta.value.viewport })
+      }
+      return defu(overrides, meta.value)
+    })
+    head.addHeadObjs(headObj as any)
+
+    const vm = getCurrentInstance()
+    const ctxUid = vm?.uid
+    const hydrateId = ctxUid - vm?.root.uid
+
+    if (process.server) {
+      if (ctxUid) {
+        head._ssrHydrateFromNodeId = hydrateId
+      }
+      return
+    }
+
+    watch(headReady, (ready) => {
+      if (
+        ready &&
+        (head._ssrHydrateFromNodeId === hydrateId ||
+          head._ssrHydrateFromNodeId === false)
+      ) {
+        head.updateDOM()
+      }
+    })
+
+    // any reactive change we push straight away outside of hydration updateDOM
+    watch(
+      meta,
+      () => {
+        head.updateDOM()
+      },
+      {
+        deep: true,
+      },
+    )
+
+    if (!vm) {
+      return
+    }
+
+    onBeforeUnmount(() => {
+      head.removeHeadObjs(headObj as any)
+      head.updateDOM()
+    })
+  }
+
+  if (process.server) {
+    nuxtApp.ssrContext!.renderMeta = () => {
+      const meta = renderHeadToString(head)
+      return {
+        ...meta,
+        // resolves naming difference with NuxtMeta and @vueuse/head
+        bodyScripts: meta.bodyTags,
+      }
+    }
+  }
+})

--- a/examples/nuxt3/runtime/plugin.ts
+++ b/examples/nuxt3/runtime/plugin.ts
@@ -12,6 +12,8 @@ import type { MetaObject } from "."
 import { defineNuxtPlugin } from "#app"
 import { watch } from "#imports"
 
+// Note: This is just a copy of Nuxt's internal head plugin with modifications made for this issue
+
 export default defineNuxtPlugin((nuxtApp) => {
   const head = createHead()
 

--- a/examples/vite-ssr/pages/ssr/dedup.vue
+++ b/examples/vite-ssr/pages/ssr/dedup.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { useHead } from "../../../src"
+import { useHead } from "../../../../src"
 
 useHead({
   style: [

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
   "sideEffects": false,
   "devDependencies": {
     "@egoist/prettier-config": "^1.0.0",
-    "@nuxt/test-utils": "3.0.0-rc.10",
+    "@nuxt/kit": "3.0.0-rc.11",
+    "@nuxt/test-utils": "3.0.0-rc.11",
     "@vitejs/plugin-vue": "^3.1.0",
     "@vitejs/plugin-vue-jsx": "^2.0.1",
     "@vue/compiler-sfc": "^3.2.39",
@@ -59,7 +60,7 @@
     "kanpai": "^0.11.0",
     "lint-staged": "^13.0.3",
     "mlly": "^0.5.14",
-    "nuxt": "3.0.0-rc.10",
+    "nuxt": "3.0.0-rc.11",
     "pathe": "^0.3.7",
     "playwright": "^1.25.2",
     "prettier": "^2.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,8 @@ overrides:
 
 specifiers:
   '@egoist/prettier-config': ^1.0.0
-  '@nuxt/test-utils': 3.0.0-rc.10
+  '@nuxt/kit': 3.0.0-rc.11
+  '@nuxt/test-utils': 3.0.0-rc.11
   '@vitejs/plugin-vue': ^3.1.0
   '@vitejs/plugin-vue-jsx': ^2.0.1
   '@vue/compiler-sfc': ^3.2.39
@@ -18,7 +19,7 @@ specifiers:
   kanpai: ^0.11.0
   lint-staged: ^13.0.3
   mlly: ^0.5.14
-  nuxt: 3.0.0-rc.10
+  nuxt: 3.0.0-rc.11
   pathe: ^0.3.7
   playwright: ^1.25.2
   prettier: ^2.7.1
@@ -35,7 +36,8 @@ dependencies:
 
 devDependencies:
   '@egoist/prettier-config': 1.0.0
-  '@nuxt/test-utils': 3.0.0-rc.10_vite@3.1.2+vue@3.2.39
+  '@nuxt/kit': 3.0.0-rc.11_vite@3.1.2
+  '@nuxt/test-utils': 3.0.0-rc.11_vite@3.1.2+vue@3.2.39
   '@vitejs/plugin-vue': 3.1.0_vite@3.1.2+vue@3.2.39
   '@vitejs/plugin-vue-jsx': 2.0.1_vite@3.1.2+vue@3.2.39
   '@vue/compiler-sfc': 3.2.39
@@ -47,7 +49,7 @@ devDependencies:
   kanpai: 0.11.0
   lint-staged: 13.0.3
   mlly: 0.5.14
-  nuxt: 3.0.0-rc.10_rotfulo2ionxm6wnqfjte3okw4
+  nuxt: 3.0.0-rc.11_rotfulo2ionxm6wnqfjte3okw4
   pathe: 0.3.7
   playwright: 1.25.2
   prettier: 2.7.1
@@ -378,8 +380,28 @@ packages:
     resolution: {integrity: sha512-D1Tp9Jv4aVoEo3cOAO966gFCI0wx/1lZ6sEHX8uMAfyVxuxD2+knGxhfGlb/FNLxWV3ifSI5hOmB/zFfsi7Rzw==}
     dev: true
 
+  /@esbuild/android-arm/0.15.8:
+    resolution: {integrity: sha512-CyEWALmn+no/lbgbAJsbuuhT8s2J19EJGHkeyAwjbFJMrj80KJ9zuYsoAvidPTU7BgBf87r/sgae8Tw0dbOc4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dependencies:
+      esbuild-wasm: 0.15.8
+    dev: true
+    optional: true
+
   /@esbuild/linux-loong64/0.15.7:
     resolution: {integrity: sha512-IKznSJOsVUuyt7cDzzSZyqBEcZe+7WlBqTVXiF1OXP/4Nm387ToaXZ0fyLwI1iBlI/bzpxVq411QE2/Bt2XWWw==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-loong64/0.15.8:
+    resolution: {integrity: sha512-pE5RQsOTSERCtfZdfCT25wzo7dfhOSlhAXcsZmuvRYhendOv7djcdvtINdnDp2DAjP17WXlBB4nBO6sHLczmsg==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -427,7 +449,7 @@ packages:
     resolution: {integrity: sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==}
     dependencies:
       '@jridgewell/gen-mapping': 0.3.2
-      '@jridgewell/trace-mapping': 0.3.14
+      '@jridgewell/trace-mapping': 0.3.15
     dev: true
 
   /@jridgewell/sourcemap-codec/1.4.11:
@@ -502,52 +524,22 @@ packages:
     resolution: {integrity: sha512-YBI/6o2EBz02tdEJRBK8xkt3zvOFOWlLBf7WKYGBsSYSRtjjgrqPe2skp6VLLmKx5WbHHDNcW+6oACaurxGzeA==}
     dev: true
 
-  /@nuxt/kit/3.0.0-rc.10_gdklb7vs65oca6qjnjub6mgwyy:
-    resolution: {integrity: sha512-sJEuvM6JTOWULRTLN0R4vZZYxus0ylevrCUELnez3GHedeDPopFrjFd8G+pZWTid9wix4SS3izWBvOJx9mLGlQ==}
+  /@nuxt/kit/3.0.0-rc.11_vite@3.1.2:
+    resolution: {integrity: sha512-o0E/k635Lzcxp4K5t0ToHC6WwQ1wyN0EIqMAQEzgiUexoAhzdURr21QI0D6e6U461u4KP7x92wYM87VxhMFXmQ==}
     engines: {node: ^14.16.0 || ^16.11.0 || ^17.0.0 || ^18.0.0}
     dependencies:
-      '@nuxt/schema': 3.0.0-rc.10_gdklb7vs65oca6qjnjub6mgwyy
-      c12: 0.2.12
+      '@nuxt/schema': 3.0.0-rc.11_vite@3.1.2
+      c12: 0.2.13
       consola: 2.15.3
       defu: 6.1.0
       globby: 13.1.2
       hash-sum: 2.0.0
       ignore: 5.2.0
-      jiti: 1.15.0
+      jiti: 1.16.0
       knitwork: 0.1.2
       lodash.template: 4.5.0
-      mlly: 0.5.14
-      pathe: 0.3.7
-      pkg-types: 0.3.5
-      scule: 0.3.2
-      semver: 7.3.7
-      unctx: 2.0.2_gdklb7vs65oca6qjnjub6mgwyy
-      unimport: 0.6.7_gdklb7vs65oca6qjnjub6mgwyy
-      untyped: 0.5.0
-    transitivePeerDependencies:
-      - esbuild
-      - rollup
-      - supports-color
-      - vite
-      - webpack
-    dev: true
-
-  /@nuxt/kit/3.0.0-rc.10_vite@3.1.2:
-    resolution: {integrity: sha512-sJEuvM6JTOWULRTLN0R4vZZYxus0ylevrCUELnez3GHedeDPopFrjFd8G+pZWTid9wix4SS3izWBvOJx9mLGlQ==}
-    engines: {node: ^14.16.0 || ^16.11.0 || ^17.0.0 || ^18.0.0}
-    dependencies:
-      '@nuxt/schema': 3.0.0-rc.10_vite@3.1.2
-      c12: 0.2.12
-      consola: 2.15.3
-      defu: 6.1.0
-      globby: 13.1.2
-      hash-sum: 2.0.0
-      ignore: 5.2.0
-      jiti: 1.15.0
-      knitwork: 0.1.2
-      lodash.template: 4.5.0
-      mlly: 0.5.14
-      pathe: 0.3.7
+      mlly: 0.5.16
+      pathe: 0.3.8
       pkg-types: 0.3.5
       scule: 0.3.2
       semver: 7.3.7
@@ -562,37 +554,45 @@ packages:
       - webpack
     dev: true
 
-  /@nuxt/schema/3.0.0-rc.10_gdklb7vs65oca6qjnjub6mgwyy:
-    resolution: {integrity: sha512-mHb+5qp3H07QvASA/fGEnUWx4S3plBt6nqZmPewxDuBys2au/PCBJBQiwKioBLgQvFPqysirScpLYPFKy3qdJw==}
+  /@nuxt/kit/3.0.0-rc.11_yrghuvd3zkjqr2aqvquijs2oqu:
+    resolution: {integrity: sha512-o0E/k635Lzcxp4K5t0ToHC6WwQ1wyN0EIqMAQEzgiUexoAhzdURr21QI0D6e6U461u4KP7x92wYM87VxhMFXmQ==}
     engines: {node: ^14.16.0 || ^16.11.0 || ^17.0.0 || ^18.0.0}
     dependencies:
-      c12: 0.2.12
-      create-require: 1.1.1
+      '@nuxt/schema': 3.0.0-rc.11_yrghuvd3zkjqr2aqvquijs2oqu
+      c12: 0.2.13
+      consola: 2.15.3
       defu: 6.1.0
-      jiti: 1.15.0
-      pathe: 0.3.7
+      globby: 13.1.2
+      hash-sum: 2.0.0
+      ignore: 5.2.0
+      jiti: 1.16.0
+      knitwork: 0.1.2
+      lodash.template: 4.5.0
+      mlly: 0.5.16
+      pathe: 0.3.8
       pkg-types: 0.3.5
-      postcss-import-resolver: 2.0.0
       scule: 0.3.2
-      std-env: 3.2.1
-      ufo: 0.8.5
-      unimport: 0.6.7_gdklb7vs65oca6qjnjub6mgwyy
+      semver: 7.3.7
+      unctx: 2.0.2_yrghuvd3zkjqr2aqvquijs2oqu
+      unimport: 0.6.7_yrghuvd3zkjqr2aqvquijs2oqu
+      untyped: 0.5.0
     transitivePeerDependencies:
       - esbuild
       - rollup
+      - supports-color
       - vite
       - webpack
     dev: true
 
-  /@nuxt/schema/3.0.0-rc.10_vite@3.1.2:
-    resolution: {integrity: sha512-mHb+5qp3H07QvASA/fGEnUWx4S3plBt6nqZmPewxDuBys2au/PCBJBQiwKioBLgQvFPqysirScpLYPFKy3qdJw==}
+  /@nuxt/schema/3.0.0-rc.11_vite@3.1.2:
+    resolution: {integrity: sha512-EIBYQeBxJ+JZ8RjPRGaXM9+vtWMHQ4HsqZIw5a+p6hqRLGf53fHANT4vjMQZA4fAYBnJZJI7dB/OXkfyb/kikA==}
     engines: {node: ^14.16.0 || ^16.11.0 || ^17.0.0 || ^18.0.0}
     dependencies:
-      c12: 0.2.12
+      c12: 0.2.13
       create-require: 1.1.1
       defu: 6.1.0
-      jiti: 1.15.0
-      pathe: 0.3.7
+      jiti: 1.16.0
+      pathe: 0.3.8
       pkg-types: 0.3.5
       postcss-import-resolver: 2.0.0
       scule: 0.3.2
@@ -606,11 +606,33 @@ packages:
       - webpack
     dev: true
 
+  /@nuxt/schema/3.0.0-rc.11_yrghuvd3zkjqr2aqvquijs2oqu:
+    resolution: {integrity: sha512-EIBYQeBxJ+JZ8RjPRGaXM9+vtWMHQ4HsqZIw5a+p6hqRLGf53fHANT4vjMQZA4fAYBnJZJI7dB/OXkfyb/kikA==}
+    engines: {node: ^14.16.0 || ^16.11.0 || ^17.0.0 || ^18.0.0}
+    dependencies:
+      c12: 0.2.13
+      create-require: 1.1.1
+      defu: 6.1.0
+      jiti: 1.16.0
+      pathe: 0.3.8
+      pkg-types: 0.3.5
+      postcss-import-resolver: 2.0.0
+      scule: 0.3.2
+      std-env: 3.2.1
+      ufo: 0.8.5
+      unimport: 0.6.7_yrghuvd3zkjqr2aqvquijs2oqu
+    transitivePeerDependencies:
+      - esbuild
+      - rollup
+      - vite
+      - webpack
+    dev: true
+
   /@nuxt/telemetry/2.1.5_vite@3.1.2:
     resolution: {integrity: sha512-Goi35DKG0Na7k/lPcaZkEvb+TWPdXKtyRixvcMMtvdbzjqGD/+gMy9BtHuS051LxdVZBNWBFyGVwT+DqlkVZKw==}
     hasBin: true
     dependencies:
-      '@nuxt/kit': 3.0.0-rc.10_vite@3.1.2
+      '@nuxt/kit': 3.0.0-rc.11_vite@3.1.2
       chalk: 5.0.1
       ci-info: 3.4.0
       consola: 2.15.3
@@ -622,11 +644,11 @@ packages:
       git-url-parse: 13.1.0
       inquirer: 9.1.1
       is-docker: 3.0.0
-      jiti: 1.15.0
+      jiti: 1.16.0
       mri: 1.2.0
       nanoid: 4.0.0
       node-fetch: 3.2.10
-      ohmyfetch: 0.4.18
+      ohmyfetch: 0.4.19
       parse-git-config: 3.0.0
       rc9: 1.2.2
       std-env: 3.2.1
@@ -638,20 +660,20 @@ packages:
       - webpack
     dev: true
 
-  /@nuxt/test-utils/3.0.0-rc.10_vite@3.1.2+vue@3.2.39:
-    resolution: {integrity: sha512-6+h9uj7wP0XSiqpxWBQJSZn1ysi/4YHeAHoDOTMsNwcdoQ2Qqe4me4tJ5ILj3L7qjDarBVhrDOSefsi2cosnBw==}
+  /@nuxt/test-utils/3.0.0-rc.11_vite@3.1.2+vue@3.2.39:
+    resolution: {integrity: sha512-9k6MpDSiZb/PEYz1xyklorXKdCX597EicJlLCblHhjiCvrjkejAxl9MCj8NWIaS2HIWjUhLNZDQ+sVaowjjSGA==}
     engines: {node: ^14.16.0 || ^16.11.0 || ^17.0.0 || ^18.0.0}
     peerDependencies:
       vue: ^3.2.39
     dependencies:
-      '@nuxt/kit': 3.0.0-rc.10_vite@3.1.2
-      '@nuxt/schema': 3.0.0-rc.10_vite@3.1.2
+      '@nuxt/kit': 3.0.0-rc.11_vite@3.1.2
+      '@nuxt/schema': 3.0.0-rc.11_vite@3.1.2
       consola: 2.15.3
       defu: 6.1.0
       execa: 6.1.0
       get-port-please: 2.6.1
-      jiti: 1.15.0
-      ohmyfetch: 0.4.18
+      jiti: 1.16.0
+      ohmyfetch: 0.4.19
       vue: 3.2.39
     transitivePeerDependencies:
       - esbuild
@@ -661,25 +683,25 @@ packages:
       - webpack
     dev: true
 
-  /@nuxt/ui-templates/0.3.3:
-    resolution: {integrity: sha512-EgxICRWv+VCkt3wjCuJUJqNOFACF3h6FX3Mj+hDXshf6ECvl/y8BWEVGC5T2N8tE/bFcNC6rEJxPsp4s+4+XOQ==}
+  /@nuxt/ui-templates/0.4.0:
+    resolution: {integrity: sha512-oFjUfn9r9U4vNljd5uU08+6M3mF6OSxZfCrfqJQaN5TtqVTcZmZFzOZ4H866Lq+Eaugv/Vte225kuaZCB3FR/g==}
     dev: true
 
-  /@nuxt/vite-builder/3.0.0-rc.10_arz4dztosvwy2ghjrlh2wdhejm:
-    resolution: {integrity: sha512-Ow6f11E1wZfyBGy0Y70IDj1pdmAfLFYw2IUqrT9Y6r6fGzKxeaO1k5g2VCt7X+Ju6c3dCZNZPWQPuBSsLvRRSg==}
+  /@nuxt/vite-builder/3.0.0-rc.11_arz4dztosvwy2ghjrlh2wdhejm:
+    resolution: {integrity: sha512-WkQ+/cfdIf5XVZea8xD+ciLXpmQkNu8d5p16WJSp10hEhj3Vt/cQ8OkXDVHGGRML+NsDL0bQXDeg3PcM/bw94w==}
     engines: {node: ^14.16.0 || ^16.11.0 || ^17.0.0 || ^18.0.0}
     peerDependencies:
       vue: ^3.2.39
     dependencies:
-      '@nuxt/kit': 3.0.0-rc.10_gdklb7vs65oca6qjnjub6mgwyy
+      '@nuxt/kit': 3.0.0-rc.11_yrghuvd3zkjqr2aqvquijs2oqu
       '@rollup/plugin-replace': 4.0.0_rollup@2.79.0
-      '@vitejs/plugin-vue': 3.1.0_vite@3.1.2+vue@3.2.39
-      '@vitejs/plugin-vue-jsx': 2.0.1_vite@3.1.2+vue@3.2.39
+      '@vitejs/plugin-vue': 3.1.0_vite@3.1.3+vue@3.2.39
+      '@vitejs/plugin-vue-jsx': 2.0.1_vite@3.1.3+vue@3.2.39
       autoprefixer: 10.4.11_postcss@8.4.16
       chokidar: 3.5.3
       cssnano: 5.1.13_postcss@8.4.16
       defu: 6.1.0
-      esbuild: 0.15.7
+      esbuild: 0.15.8
       escape-string-regexp: 5.0.0
       estree-walker: 3.0.1
       externality: 0.2.2
@@ -688,9 +710,9 @@ packages:
       h3: 0.7.21
       knitwork: 0.1.2
       magic-string: 0.26.3
-      mlly: 0.5.14
+      mlly: 0.5.16
       ohash: 0.1.5
-      pathe: 0.3.7
+      pathe: 0.3.8
       perfect-debounce: 0.1.3
       pkg-types: 0.3.5
       postcss: 8.4.16
@@ -699,10 +721,10 @@ packages:
       rollup: 2.79.0
       rollup-plugin-visualizer: 5.8.1_rollup@2.79.0
       ufo: 0.8.5
-      unplugin: 0.9.5_gdklb7vs65oca6qjnjub6mgwyy
-      vite: 3.1.2
+      unplugin: 0.9.5_yrghuvd3zkjqr2aqvquijs2oqu
+      vite: 3.1.3
       vite-node: 0.23.4
-      vite-plugin-checker: 0.5.1_rotfulo2ionxm6wnqfjte3okw4
+      vite-plugin-checker: 0.5.1_qzzqzik23fiaove4fwm46zpole
       vue: 3.2.39
       vue-bundle-renderer: 0.4.3
     transitivePeerDependencies:
@@ -893,6 +915,23 @@ packages:
       - supports-color
     dev: true
 
+  /@vitejs/plugin-vue-jsx/2.0.1_vite@3.1.3+vue@3.2.39:
+    resolution: {integrity: sha512-lmiR1k9+lrF7LMczO0pxtQ8mOn6XeppJDHxnpxkJQpT5SiKz4SKhKdeNstXaTNuR8qZhUo5X0pJlcocn72Y4Jg==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^3.0.0
+      vue: ^3.0.0
+    dependencies:
+      '@babel/core': 7.19.1
+      '@babel/plugin-syntax-import-meta': 7.10.4_@babel+core@7.19.1
+      '@babel/plugin-transform-typescript': 7.19.1_@babel+core@7.19.1
+      '@vue/babel-plugin-jsx': 1.1.1_@babel+core@7.19.1
+      vite: 3.1.3
+      vue: 3.2.39
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@vitejs/plugin-vue/3.1.0_vite@3.1.2+vue@3.2.39:
     resolution: {integrity: sha512-fmxtHPjSOEIRg6vHYDaem+97iwCUg/uSIaTzp98lhELt2ISOQuDo2hbkBdXod0g15IhfPMQmAxh4heUks2zvDA==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -901,6 +940,17 @@ packages:
       vue: ^3.2.25
     dependencies:
       vite: 3.1.2
+      vue: 3.2.39
+    dev: true
+
+  /@vitejs/plugin-vue/3.1.0_vite@3.1.3+vue@3.2.39:
+    resolution: {integrity: sha512-fmxtHPjSOEIRg6vHYDaem+97iwCUg/uSIaTzp98lhELt2ISOQuDo2hbkBdXod0g15IhfPMQmAxh4heUks2zvDA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^3.0.0
+      vue: ^3.2.25
+    dependencies:
+      vite: 3.1.3
       vue: 3.2.39
     dev: true
 
@@ -1329,15 +1379,15 @@ packages:
       load-tsconfig: 0.2.3
     dev: true
 
-  /c12/0.2.12:
-    resolution: {integrity: sha512-Oq+XDrx2luek30VrWU0QXrvPbILAp8fDVgprRvhP4WL4CZaSqE7CNHIhq1R824YSkMVUOfMjsZFRcVqs7I2Xxg==}
+  /c12/0.2.13:
+    resolution: {integrity: sha512-wJL0/knDbqM/3moLb+8Xd+w3JdkggkIIhiNBkxZ1mWlskKC/vajb85wM3UPg/D9nK6RbI1NgaVTg6AeXBVbknA==}
     dependencies:
       defu: 6.1.0
       dotenv: 16.0.2
       gittar: 0.1.1
-      jiti: 1.15.0
-      mlly: 0.5.14
-      pathe: 0.3.7
+      jiti: 1.16.0
+      mlly: 0.5.16
+      pathe: 0.3.8
       pkg-types: 0.3.5
       rc9: 1.2.2
     dev: true
@@ -1766,7 +1816,7 @@ packages:
       postcss: ^8.2.15
     dependencies:
       cssnano-preset-default: 5.2.12_postcss@8.4.16
-      lilconfig: 2.0.5
+      lilconfig: 2.0.6
       postcss: 8.4.16
       yaml: 1.10.2
     dev: true
@@ -2058,8 +2108,28 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-android-64/0.15.8:
+    resolution: {integrity: sha512-bVh8FIKOolF7/d4AMzt7xHlL0Ljr+mYKSHI39TJWDkybVWHdn6+4ODL3xZGHOxPpdRpitemXA1WwMKYBsw8dGw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dependencies:
+      esbuild-wasm: 0.15.8
+    dev: true
+    optional: true
+
   /esbuild-android-arm64/0.15.7:
     resolution: {integrity: sha512-L775l9ynJT7rVqRM5vo+9w5g2ysbOCfsdLV4CWanTZ1k/9Jb3IYlQ06VCI1edhcosTYJRECQFJa3eAvkx72eyQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-android-arm64/0.15.8:
+    resolution: {integrity: sha512-ReAMDAHuo0H1h9LxRabI6gwYPn8k6WiUeyxuMvx17yTrJO+SCnIfNc/TSPFvDwtK9MiyiKG/2dBYHouT/M0BXQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -2076,8 +2146,26 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-darwin-64/0.15.8:
+    resolution: {integrity: sha512-KaKcGfJ+yto7Fo5gAj3xwxHMd1fBIKatpCHK8znTJLVv+9+NN2/tIPBqA4w5rBwjX0UqXDeIE2v1xJP+nGEXgA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-darwin-arm64/0.15.7:
     resolution: {integrity: sha512-kBIHvtVqbSGajN88lYMnR3aIleH3ABZLLFLxwL2stiuIGAjGlQW741NxVTpUHQXUmPzxi6POqc9npkXa8AcSZQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-darwin-arm64/0.15.8:
+    resolution: {integrity: sha512-8tjEaBgAKnXCkP7bhEJmEqdG9HEV6oLkF36BrMzpfW2rgaw0c48Zrxe+9RlfeGvs6gDF4w+agXyTjikzsS3izw==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
@@ -2094,8 +2182,26 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-freebsd-64/0.15.8:
+    resolution: {integrity: sha512-jaxcsGHYzn2L0/lffON2WfH4Nc+d/EwozVTP5K2v016zxMb5UQMhLoJzvLgBqHT1SG0B/mO+a+THnJCMVg15zw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-freebsd-arm64/0.15.7:
     resolution: {integrity: sha512-dLFR0ChH5t+b3J8w0fVKGvtwSLWCv7GYT2Y2jFGulF1L5HftQLzVGN+6pi1SivuiVSmTh28FwUhi9PwQicXI6Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-freebsd-arm64/0.15.8:
+    resolution: {integrity: sha512-2xp2UlljMvX8HExtcg7VHaeQk8OBU0CSl1j18B5CcZmSDkLF9p3utuMXIopG3a08fr9Hv+Dz6+seSXUow/G51w==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
@@ -2112,8 +2218,26 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-linux-32/0.15.8:
+    resolution: {integrity: sha512-9u1E54BRz1FQMl86iaHK146+4ID2KYNxL3trLZT4QLLx3M7Q9n4lGG3lrzqUatGR2cKy8c33b0iaCzsItZWkFg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-linux-64/0.15.7:
     resolution: {integrity: sha512-LxXEfLAKwOVmm1yecpMmWERBshl+Kv5YJ/1KnyAr6HRHFW8cxOEsEfisD3sVl/RvHyW//lhYUVSuy9jGEfIRAQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-64/0.15.8:
+    resolution: {integrity: sha512-4HxrsN9eUzJXdVGMTYA5Xler82FuZUu21bXKN42zcLHHNKCAMPUzD62I+GwDhsdgUBAUj0tRXDdsQHgaP6v0HA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -2130,8 +2254,26 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-linux-arm/0.15.8:
+    resolution: {integrity: sha512-7DVBU9SFjX4+vBwt8tHsUCbE6Vvl6y6FQWHAgyw1lybC5gULqn/WnjHYHN2/LJaZRsDBvxWT4msEgwLGq1Wd3Q==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-linux-arm64/0.15.7:
     resolution: {integrity: sha512-P3cfhudpzWDkglutWgXcT2S7Ft7o2e3YDMrP1n0z2dlbUZghUkKCyaWw0zhp4KxEEzt/E7lmrtRu/pGWnwb9vw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-arm64/0.15.8:
+    resolution: {integrity: sha512-1OCm7Aq0tEJT70PbxmHSGYDLYP8DKH8r4Nk7/XbVzWaduo9beCjGBB+tGZIHK6DdTQ3h00/4Tb/70YMH/bOtKg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
@@ -2148,8 +2290,26 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-linux-mips64le/0.15.8:
+    resolution: {integrity: sha512-yeFoNPVFPEzZvFYBfUQNG2TjGRaCyV1E27OcOg4LOtnGrxb2wA+mkW3luckyv1CEyd00mpAg7UdHx8nlx3ghgA==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-linux-ppc64le/0.15.7:
     resolution: {integrity: sha512-6mGuC19WpFN7NYbecMIJjeQgvDb5aMuvyk0PDYBJrqAEMkTwg3Z98kEKuCm6THHRnrgsdr7bp4SruSAxEM4eJw==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-ppc64le/0.15.8:
+    resolution: {integrity: sha512-CEyMMUUNabXibw8OSNmBXhOIGhnjNVl5Lpseiuf00iKN0V47oqDrbo4dsHz1wH62m49AR8iG8wpDlTqfYgKbtg==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -2166,8 +2326,26 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-linux-riscv64/0.15.8:
+    resolution: {integrity: sha512-OCGSOaspMUjexSCU8ZiA0UnV/NiRU+s2vIfEcAQWQ6u32R+2luyfh/4ZaY6jFbylJE07Esc/yRvb9Q5fXuClXA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-linux-s390x/0.15.7:
     resolution: {integrity: sha512-+tO+xOyTNMc34rXlSxK7aCwJgvQyffqEM5MMdNDEeMU3ss0S6wKvbBOQfgd5jRPblfwJ6b+bKiz0g5nABpY0QQ==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-s390x/0.15.8:
+    resolution: {integrity: sha512-RHdpdfxRTSrZXZJlFSLazFU4YwXLB5Rgf6Zr5rffqSsO4y9JybgtKO38bFwxZNlDXliYISXN/YROKrG9s7mZQA==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -2184,8 +2362,26 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-netbsd-64/0.15.8:
+    resolution: {integrity: sha512-VolFFRatBH09T5QMWhiohAWCOien1R1Uz9K0BRVVTBgBaVBt7eArsXTKxVhUgRf2vwu2c2SXkuP0r7HLG0eozw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-openbsd-64/0.15.7:
     resolution: {integrity: sha512-GsimbwC4FSR4lN3wf8XmTQ+r8/0YSQo21rWDL0XFFhLHKlzEA4SsT1Tl8bPYu00IU6UWSJ+b3fG/8SB69rcuEQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-openbsd-64/0.15.8:
+    resolution: {integrity: sha512-HTAPlg+n4kUeE/isQxlCfsOz0xJGNoT5LJ9oYZWFKABfVf4Ycu7Zlf5ITgOnrdheTkz8JeL/gISIOCFAoOXrSA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -2202,8 +2398,34 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-sunos-64/0.15.8:
+    resolution: {integrity: sha512-qMP/jR/FzcIOwKj+W+Lb+8Cfr8GZHbHUJxAPi7DUhNZMQ/6y7sOgRzlOSpRrbbUntrRZh0MqOyDhJ3Gpo6L1QA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-wasm/0.15.8:
+    resolution: {integrity: sha512-Y7uCl5RNO4URjlemjdx++ukVHEMt5s5AfMWYUnMiK4Sry+pPCvQIctzXq6r6FKCyGKjX6/NGMCqR2OX6aLxj0w==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-windows-32/0.15.7:
     resolution: {integrity: sha512-cOnKXUEPS8EGCzRSFa1x6NQjGhGsFlVgjhqGEbLTPsA7x4RRYiy2RKoArNUU4iR2vHmzqS5Gr84MEumO/wxYKA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-windows-32/0.15.8:
+    resolution: {integrity: sha512-RKR1QHh4iWzjUhkP8Yqi75PPz/KS+b8zw3wUrzw6oAkj+iU5Qtyj61ZDaSG3Qf2vc6hTIUiPqVTqBH0NpXFNwg==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
@@ -2220,8 +2442,26 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-windows-64/0.15.8:
+    resolution: {integrity: sha512-ag9ptYrsizgsR+PQE8QKeMqnosLvAMonQREpLw4evA4FFgOBMLEat/dY/9txbpozTw9eEOYyD3a4cE9yTu20FA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-windows-arm64/0.15.7:
     resolution: {integrity: sha512-R06nmqBlWjKHddhRJYlqDd3Fabx9LFdKcjoOy08YLimwmsswlFBJV4rXzZCxz/b7ZJXvrZgj8DDv1ewE9+StMw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-windows-arm64/0.15.8:
+    resolution: {integrity: sha512-dbpAb0VyPaUs9mgw65KRfQ9rqiWCHpNzrJusoPu+LpEoswosjt/tFxN7cd2l68AT4qWdBkzAjDLRon7uqMeWcg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -2256,6 +2496,36 @@ packages:
       esbuild-windows-32: 0.15.7
       esbuild-windows-64: 0.15.7
       esbuild-windows-arm64: 0.15.7
+    dev: true
+
+  /esbuild/0.15.8:
+    resolution: {integrity: sha512-Remsk2dmr1Ia65sU+QasE6svJbsHe62lzR+CnjpUvbZ+uSYo1SitiOWPRfZQkCu82YWZBBKXiD/j0i//XWMZ+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/android-arm': 0.15.8
+      '@esbuild/linux-loong64': 0.15.8
+      esbuild-android-64: 0.15.8
+      esbuild-android-arm64: 0.15.8
+      esbuild-darwin-64: 0.15.8
+      esbuild-darwin-arm64: 0.15.8
+      esbuild-freebsd-64: 0.15.8
+      esbuild-freebsd-arm64: 0.15.8
+      esbuild-linux-32: 0.15.8
+      esbuild-linux-64: 0.15.8
+      esbuild-linux-arm: 0.15.8
+      esbuild-linux-arm64: 0.15.8
+      esbuild-linux-mips64le: 0.15.8
+      esbuild-linux-ppc64le: 0.15.8
+      esbuild-linux-riscv64: 0.15.8
+      esbuild-linux-s390x: 0.15.8
+      esbuild-netbsd-64: 0.15.8
+      esbuild-openbsd-64: 0.15.8
+      esbuild-sunos-64: 0.15.8
+      esbuild-windows-32: 0.15.8
+      esbuild-windows-64: 0.15.8
+      esbuild-windows-arm64: 0.15.8
     dev: true
 
   /escalade/3.1.1:
@@ -2373,20 +2643,9 @@ packages:
     resolution: {integrity: sha512-seYffJRrRVI3qrCC0asf2mWAvQ/U0jZA+eECylqIxCDHzBs/W+ZeEv3D0bsjNeEewIYZKfELyY96mRactx8C4w==}
     dependencies:
       enhanced-resolve: 5.10.0
-      mlly: 0.5.14
-      pathe: 0.3.7
+      mlly: 0.5.16
+      pathe: 0.3.8
       ufo: 0.8.5
-    dev: true
-
-  /fast-glob/3.2.11:
-    resolution: {integrity: sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==}
-    engines: {node: '>=8.6.0'}
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      '@nodelib/fs.walk': 1.2.8
-      glob-parent: 5.1.2
-      merge2: 1.4.1
-      micromatch: 4.0.5
     dev: true
 
   /fast-glob/3.2.12:
@@ -2629,7 +2888,7 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       dir-glob: 3.0.1
-      fast-glob: 3.2.11
+      fast-glob: 3.2.12
       ignore: 5.2.0
       merge2: 1.4.1
       slash: 4.0.0
@@ -2844,6 +3103,11 @@ packages:
       - supports-color
     dev: true
 
+  /ip-regex/5.0.0:
+    resolution: {integrity: sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: true
+
   /is-binary-path/2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
     engines: {node: '>=8'}
@@ -2976,8 +3240,8 @@ packages:
       supports-color: 7.2.0
     dev: true
 
-  /jiti/1.15.0:
-    resolution: {integrity: sha512-cClBkETOCVIpPMjX3ULlivuBvmt8l2Xtz+SHrULO06OqdtV0QFR2cuhc4FJnXByjUUX4CY0pl1nph0aFh9D3yA==}
+  /jiti/1.16.0:
+    resolution: {integrity: sha512-L3BJStEf5NAqNuzrpfbN71dp43mYIcBUlCRea/vdyv5dW/AYa1d4bpelko4SHdY3I6eN9Wzyasxirj1/vv5kmg==}
     hasBin: true
     dev: true
 
@@ -3132,6 +3396,19 @@ packages:
       get-port-please: 2.6.1
       http-shutdown: 1.2.2
       selfsigned: 2.1.1
+      ufo: 0.8.5
+    dev: true
+
+  /listhen/0.3.4:
+    resolution: {integrity: sha512-cuzWWoIWF8JvsPLmIurTkUXi27owH4RRKnBsbPswRJvB82uTv15W01yOOLaPvjxY5mMlftmW2p1XnxB835AdRA==}
+    dependencies:
+      clipboardy: 3.0.0
+      colorette: 2.0.19
+      defu: 6.1.0
+      get-port-please: 2.6.1
+      http-shutdown: 1.2.2
+      ip-regex: 5.0.0
+      node-forge: 1.3.1
       ufo: 0.8.5
     dev: true
 
@@ -3415,6 +3692,15 @@ packages:
       ufo: 0.8.5
     dev: true
 
+  /mlly/0.5.16:
+    resolution: {integrity: sha512-LaJ8yuh4v0zEmge/g3c7jjFlhoCPfQn6RCjXgm9A0Qiuochq4BcuOxVfWmdnCoLTlg2MV+hqhOek+W2OhG0Lwg==}
+    dependencies:
+      acorn: 8.8.0
+      pathe: 0.3.8
+      pkg-types: 0.3.5
+      ufo: 0.8.5
+    dev: true
+
   /mri/1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
@@ -3455,8 +3741,8 @@ packages:
     hasBin: true
     dev: true
 
-  /nitropack/0.5.3_vite@3.1.2:
-    resolution: {integrity: sha512-X54AQOAUDwuegwMaiVsWGUpG7kgOVlwUnbV9fIo4sClmwU7zmTblmM+NhiioC06r/Z5OKKM8Bj+vmIL52GBejg==}
+  /nitropack/0.5.4_vite@3.1.2:
+    resolution: {integrity: sha512-e7hNguDQLDTV5271U1PgWFC/B3HscZ6W8DG9bHfuwmiWLXRrdsMvw27yJdf6MGbqQ+p6o22ligpfIL1M54rSTg==}
     engines: {node: ^14.16.0 || ^16.11.0 || ^17.0.0 || ^18.0.0}
     hasBin: true
     dependencies:
@@ -3472,7 +3758,7 @@ packages:
       '@rollup/pluginutils': 4.2.1
       '@vercel/nft': 0.22.1
       archiver: 5.3.1
-      c12: 0.2.12
+      c12: 0.2.13
       chalk: 5.0.1
       chokidar: 3.5.3
       consola: 2.15.3
@@ -3480,7 +3766,7 @@ packages:
       defu: 6.1.0
       destr: 1.1.1
       dot-prop: 7.2.0
-      esbuild: 0.15.7
+      esbuild: 0.15.8
       escape-string-regexp: 5.0.0
       etag: 1.8.1
       fs-extra: 10.1.0
@@ -3490,17 +3776,17 @@ packages:
       hookable: 5.3.0
       http-proxy: 1.18.1
       is-primitive: 3.0.1
-      jiti: 1.15.0
+      jiti: 1.16.0
       klona: 2.0.5
       knitwork: 0.1.2
-      listhen: 0.2.15
+      listhen: 0.3.4
       mime: 3.0.0
-      mlly: 0.5.14
+      mlly: 0.5.16
       mri: 1.2.0
-      node-fetch-native: 0.1.4
+      node-fetch-native: 0.1.7
       ohash: 0.1.5
-      ohmyfetch: 0.4.18
-      pathe: 0.3.7
+      ohmyfetch: 0.4.19
+      pathe: 0.3.8
       perfect-debounce: 0.1.3
       pkg-types: 0.3.5
       pretty-bytes: 6.0.0
@@ -3516,7 +3802,7 @@ packages:
       std-env: 3.2.1
       ufo: 0.8.5
       unenv: 0.6.2
-      unimport: 0.6.7_gdklb7vs65oca6qjnjub6mgwyy
+      unimport: 0.6.7_dtdvqnq7rqavoryvihrftyo2yy
       unstorage: 0.5.6
     transitivePeerDependencies:
       - bufferutil
@@ -3533,8 +3819,8 @@ packages:
     engines: {node: '>=10.5.0'}
     dev: true
 
-  /node-fetch-native/0.1.4:
-    resolution: {integrity: sha512-10EKpOCQPXwZVFh3U1ptOMWBgKTbsN7Vvo6WVKt5pw4hp8zbv6ZVBZPlXw+5M6Tyi1oc1iD4/sNPd71KYA16tQ==}
+  /node-fetch-native/0.1.7:
+    resolution: {integrity: sha512-hps7dFJM0IEF056JftDSSjWDAwW9v2clwHoUJiHyYgl+ojoqjKyWybljMlpTmlC1O+864qovNlRLyAIjRxu9Ag==}
     dev: true
 
   /node-fetch/2.6.7:
@@ -3624,25 +3910,25 @@ packages:
       boolbase: 1.0.0
     dev: true
 
-  /nuxi/3.0.0-rc.10:
-    resolution: {integrity: sha512-gTkUm1omiWB2WN3Qj3V7MtMNLeWAEXyFi/ortayyZrNe2OOdZMMQOShmTjLdZMTAM1/Q4Ma3WIqk66gPX3EQHg==}
+  /nuxi/3.0.0-rc.11:
+    resolution: {integrity: sha512-Zz3FRkLX0pmrQAgNkiartayC5DHKBxuMsPqTkaWSXD123CtFanL2mTOwfWtuO6W+qkEA9DGWNOL+fOkfScOQJQ==}
     engines: {node: ^14.16.0 || ^16.11.0 || ^17.0.0 || ^18.0.0}
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
 
-  /nuxt/3.0.0-rc.10_rotfulo2ionxm6wnqfjte3okw4:
-    resolution: {integrity: sha512-iUIfTRrURymxrivbbhxtw+Y0Cp7PZqRVaYu/ZB0H/G7WKtLk2KRL8kl2GQKwWCJNxfEXdCQjKloTJrVVOUUqpg==}
+  /nuxt/3.0.0-rc.11_rotfulo2ionxm6wnqfjte3okw4:
+    resolution: {integrity: sha512-I0wyxPHnUoJBWoROKUx91PLKaAFZ/TsxSpcm3/jn/Ysq2RGU5Q3o9AzqT0YcXW4rgH35QPFvGpqopU9X0vS7Qw==}
     engines: {node: ^14.16.0 || ^16.11.0 || ^17.0.0 || ^18.0.0}
     hasBin: true
     dependencies:
       '@nuxt/devalue': 2.0.0
-      '@nuxt/kit': 3.0.0-rc.10_vite@3.1.2
-      '@nuxt/schema': 3.0.0-rc.10_vite@3.1.2
+      '@nuxt/kit': 3.0.0-rc.11_vite@3.1.2
+      '@nuxt/schema': 3.0.0-rc.11_vite@3.1.2
       '@nuxt/telemetry': 2.1.5_vite@3.1.2
-      '@nuxt/ui-templates': 0.3.3
-      '@nuxt/vite-builder': 3.0.0-rc.10_arz4dztosvwy2ghjrlh2wdhejm
+      '@nuxt/ui-templates': 0.4.0
+      '@nuxt/vite-builder': 3.0.0-rc.11_arz4dztosvwy2ghjrlh2wdhejm
       '@vue/reactivity': 3.2.39
       '@vue/shared': 3.2.39
       '@vueuse/head': 'link:'
@@ -3658,15 +3944,15 @@ packages:
       hookable: 5.3.0
       knitwork: 0.1.2
       magic-string: 0.26.3
-      mlly: 0.5.14
-      nitropack: 0.5.3_vite@3.1.2
-      nuxi: 3.0.0-rc.10
+      mlly: 0.5.16
+      nitropack: 0.5.4_vite@3.1.2
+      nuxi: 3.0.0-rc.11
       ohash: 0.1.5
-      ohmyfetch: 0.4.18
-      pathe: 0.3.7
+      ohmyfetch: 0.4.19
+      pathe: 0.3.8
       perfect-debounce: 0.1.3
       scule: 0.3.2
-      strip-literal: 0.4.1
+      strip-literal: 0.4.2
       ufo: 0.8.5
       unctx: 2.0.2_vite@3.1.2
       unenv: 0.6.2
@@ -3714,11 +4000,11 @@ packages:
     resolution: {integrity: sha512-qynly1AFIpGWEAW88p6DhMNqok/Swb52/KsiU+Toi7er058Ptvno3tkfTML6wYcEgFgp2GsUziW4Nqn62ciuyw==}
     dev: true
 
-  /ohmyfetch/0.4.18:
-    resolution: {integrity: sha512-MslzNrQzBLtZHmiZBI8QMOcMpdNFlK61OJ34nFNFynZ4v+4BonfCQ7VIN4EGXvGGq5zhDzgdJoY3o9S1l2T7KQ==}
+  /ohmyfetch/0.4.19:
+    resolution: {integrity: sha512-OH2xVeRPNsHkx+JFdq1ewe9EwVDfTrv6lsBHpIx8wIWXowP5FyLhhYVaXIVlPsW542rt7gmwK14FwIDWUXEO+Q==}
     dependencies:
       destr: 1.1.1
-      node-fetch-native: 0.1.4
+      node-fetch-native: 0.1.7
       ufo: 0.8.5
       undici: 5.10.0
     dev: true
@@ -3868,6 +4154,10 @@ packages:
     resolution: {integrity: sha512-yz7GK+kSsS27x727jtXpd5VT4dDfP/JDIQmaowfxyWCnFjOWtE1VIh7i6TzcSfzW0n4+bRQztj1VdKnITNq/MA==}
     dev: true
 
+  /pathe/0.3.8:
+    resolution: {integrity: sha512-c71n61F1skhj/jzZe+fWE9XDoTYjWbUwIKVwFftZ5IOgiX44BVkTkD+/803YDgR50tqeO4eXWxLyVHBLWQAD1g==}
+    dev: true
+
   /pathval/1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
     dev: true
@@ -3904,8 +4194,8 @@ packages:
     resolution: {integrity: sha512-VkxCBFVgQhNHYk9subx+HOhZ4jzynH11ah63LZsprTKwPCWG9pfWBlkElWFbvkP9BVR0dP1jS9xPdhaHQNK74Q==}
     dependencies:
       jsonc-parser: 3.2.0
-      mlly: 0.5.14
-      pathe: 0.3.7
+      mlly: 0.5.16
+      pathe: 0.3.8
     dev: true
 
   /playwright-core/1.25.2:
@@ -4782,6 +5072,12 @@ packages:
       acorn: 8.8.0
     dev: true
 
+  /strip-literal/0.4.2:
+    resolution: {integrity: sha512-pv48ybn4iE1O9RLgCAN0iU4Xv7RlBTiit6DKmMiErbs9x1wH6vXBs45tWc0H5wUIF6TLTrKweqkmYF/iraQKNw==}
+    dependencies:
+      acorn: 8.8.0
+    dev: true
+
   /stylehacks/5.1.0_postcss@8.4.16:
     resolution: {integrity: sha512-SzLmvHQTrIWfSgljkQCw2++C9+Ne91d/6Sp92I8c5uHTcy/PgeHamwITIbBW9wnFTY/3ZfSXR9HIL6Ikqmcu6Q==}
     engines: {node: ^10 || ^12 || >=14.0}
@@ -5075,20 +5371,6 @@ packages:
     resolution: {integrity: sha512-e4+UtA5IRO+ha6hYklwj6r7BjiGMxS0O+UaSg9HbaTefg4kMkzj4tXzEBajRR+wkxf+golgAWKzLbytCUDMJAA==}
     dev: true
 
-  /unctx/2.0.2_gdklb7vs65oca6qjnjub6mgwyy:
-    resolution: {integrity: sha512-3lcXTlDoOaguRVC1GqG3mrawy17yoycSAQDDnUayQYZ17v9to+Gn6Zyssroc/GD2ppJ0wF5V8adOcKkrNKVWow==}
-    dependencies:
-      acorn: 8.8.0
-      estree-walker: 3.0.1
-      magic-string: 0.26.3
-      unplugin: 0.9.5_gdklb7vs65oca6qjnjub6mgwyy
-    transitivePeerDependencies:
-      - esbuild
-      - rollup
-      - vite
-      - webpack
-    dev: true
-
   /unctx/2.0.2_vite@3.1.2:
     resolution: {integrity: sha512-3lcXTlDoOaguRVC1GqG3mrawy17yoycSAQDDnUayQYZ17v9to+Gn6Zyssroc/GD2ppJ0wF5V8adOcKkrNKVWow==}
     dependencies:
@@ -5096,6 +5378,20 @@ packages:
       estree-walker: 3.0.1
       magic-string: 0.26.3
       unplugin: 0.9.5_vite@3.1.2
+    transitivePeerDependencies:
+      - esbuild
+      - rollup
+      - vite
+      - webpack
+    dev: true
+
+  /unctx/2.0.2_yrghuvd3zkjqr2aqvquijs2oqu:
+    resolution: {integrity: sha512-3lcXTlDoOaguRVC1GqG3mrawy17yoycSAQDDnUayQYZ17v9to+Gn6Zyssroc/GD2ppJ0wF5V8adOcKkrNKVWow==}
+    dependencies:
+      acorn: 8.8.0
+      estree-walker: 3.0.1
+      magic-string: 0.26.3
+      unplugin: 0.9.5_yrghuvd3zkjqr2aqvquijs2oqu
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -5113,23 +5409,23 @@ packages:
     dependencies:
       defu: 6.1.0
       mime: 3.0.0
-      node-fetch-native: 0.1.4
-      pathe: 0.3.7
+      node-fetch-native: 0.1.7
+      pathe: 0.3.8
     dev: true
 
-  /unimport/0.6.7_gdklb7vs65oca6qjnjub6mgwyy:
+  /unimport/0.6.7_dtdvqnq7rqavoryvihrftyo2yy:
     resolution: {integrity: sha512-EMoVqDjswHkU+nD098QYHXH7Mkw7KwGDQAyeRF2lgairJnuO+wpkhIcmCqrD1OPJmsjkTbJ2tW6Ap8St0PuWZA==}
     dependencies:
       '@rollup/pluginutils': 4.2.1
       escape-string-regexp: 5.0.0
-      fast-glob: 3.2.11
+      fast-glob: 3.2.12
       local-pkg: 0.4.2
       magic-string: 0.26.3
-      mlly: 0.5.14
-      pathe: 0.3.7
+      mlly: 0.5.16
+      pathe: 0.3.8
       scule: 0.3.2
-      strip-literal: 0.4.1
-      unplugin: 0.9.5_gdklb7vs65oca6qjnjub6mgwyy
+      strip-literal: 0.4.2
+      unplugin: 0.9.5_dtdvqnq7rqavoryvihrftyo2yy
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -5142,14 +5438,34 @@ packages:
     dependencies:
       '@rollup/pluginutils': 4.2.1
       escape-string-regexp: 5.0.0
-      fast-glob: 3.2.11
+      fast-glob: 3.2.12
       local-pkg: 0.4.2
       magic-string: 0.26.3
-      mlly: 0.5.14
-      pathe: 0.3.7
+      mlly: 0.5.16
+      pathe: 0.3.8
       scule: 0.3.2
-      strip-literal: 0.4.1
+      strip-literal: 0.4.2
       unplugin: 0.9.5_vite@3.1.2
+    transitivePeerDependencies:
+      - esbuild
+      - rollup
+      - vite
+      - webpack
+    dev: true
+
+  /unimport/0.6.7_yrghuvd3zkjqr2aqvquijs2oqu:
+    resolution: {integrity: sha512-EMoVqDjswHkU+nD098QYHXH7Mkw7KwGDQAyeRF2lgairJnuO+wpkhIcmCqrD1OPJmsjkTbJ2tW6Ap8St0PuWZA==}
+    dependencies:
+      '@rollup/pluginutils': 4.2.1
+      escape-string-regexp: 5.0.0
+      fast-glob: 3.2.12
+      local-pkg: 0.4.2
+      magic-string: 0.26.3
+      mlly: 0.5.16
+      pathe: 0.3.8
+      scule: 0.3.2
+      strip-literal: 0.4.2
+      unplugin: 0.9.5_yrghuvd3zkjqr2aqvquijs2oqu
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -5167,7 +5483,7 @@ packages:
     engines: {node: '>= 10.0.0'}
     dev: true
 
-  /unplugin/0.9.5_gdklb7vs65oca6qjnjub6mgwyy:
+  /unplugin/0.9.5_dtdvqnq7rqavoryvihrftyo2yy:
     resolution: {integrity: sha512-luraheyfxwtvkvHpsOvMNv7IjLdORTWKZp0gWYNHGLi2ImON3iIZOj464qEyyEwLA/EMt12fC415HW9zRpOfTg==}
     peerDependencies:
       esbuild: '>=0.13'
@@ -5186,7 +5502,7 @@ packages:
     dependencies:
       acorn: 8.8.0
       chokidar: 3.5.3
-      esbuild: 0.15.7
+      esbuild: 0.15.8
       rollup: 2.79.0
       vite: 3.1.2
       webpack-sources: 3.2.3
@@ -5217,6 +5533,32 @@ packages:
       webpack-virtual-modules: 0.4.5
     dev: true
 
+  /unplugin/0.9.5_yrghuvd3zkjqr2aqvquijs2oqu:
+    resolution: {integrity: sha512-luraheyfxwtvkvHpsOvMNv7IjLdORTWKZp0gWYNHGLi2ImON3iIZOj464qEyyEwLA/EMt12fC415HW9zRpOfTg==}
+    peerDependencies:
+      esbuild: '>=0.13'
+      rollup: ^2.50.0
+      vite: ^2.3.0 || ^3.0.0-0
+      webpack: 4 || 5
+    peerDependenciesMeta:
+      esbuild:
+        optional: true
+      rollup:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
+    dependencies:
+      acorn: 8.8.0
+      chokidar: 3.5.3
+      esbuild: 0.15.8
+      rollup: 2.79.0
+      vite: 3.1.3
+      webpack-sources: 3.2.3
+      webpack-virtual-modules: 0.4.5
+    dev: true
+
   /unstorage/0.5.6:
     resolution: {integrity: sha512-TUm1ZyLkVamRfM+uWmWtavlzri3XS0ajYXKhlrAZ8aCChMwH29lufOfAP0bsMaBHuciIVfycaGgNhHeyLONpdA==}
     dependencies:
@@ -5227,7 +5569,7 @@ packages:
       ioredis: 5.2.3
       listhen: 0.2.15
       mri: 1.2.0
-      ohmyfetch: 0.4.18
+      ohmyfetch: 0.4.19
       ufo: 0.8.5
       ws: 8.8.1
     transitivePeerDependencies:
@@ -5275,9 +5617,9 @@ packages:
     hasBin: true
     dependencies:
       debug: 4.3.4
-      mlly: 0.5.14
+      mlly: 0.5.16
       pathe: 0.2.0
-      vite: 3.1.2
+      vite: 3.1.3
     transitivePeerDependencies:
       - less
       - sass
@@ -5286,7 +5628,7 @@ packages:
       - terser
     dev: true
 
-  /vite-plugin-checker/0.5.1_rotfulo2ionxm6wnqfjte3okw4:
+  /vite-plugin-checker/0.5.1_qzzqzik23fiaove4fwm46zpole:
     resolution: {integrity: sha512-NFiO1PyK9yGuaeSnJ7Whw9fnxLc1AlELnZoyFURnauBYhbIkx9n+PmIXxSFUuC9iFyACtbJQUAEuQi6yHs2Adg==}
     engines: {node: '>=14.16'}
     peerDependencies:
@@ -5310,14 +5652,14 @@ packages:
       chalk: 4.1.2
       chokidar: 3.5.3
       commander: 8.3.0
-      fast-glob: 3.2.11
+      fast-glob: 3.2.12
       lodash.debounce: 4.0.8
       lodash.pick: 4.4.0
       npm-run-path: 4.0.1
       strip-ansi: 6.0.1
       tiny-invariant: 1.2.0
       typescript: 4.8.3
-      vite: 3.1.2
+      vite: 3.1.3
       vscode-languageclient: 7.0.0
       vscode-languageserver: 7.0.0
       vscode-languageserver-textdocument: 1.0.7
@@ -5344,6 +5686,33 @@ packages:
         optional: true
     dependencies:
       esbuild: 0.15.7
+      postcss: 8.4.16
+      resolve: 1.22.1
+      rollup: 2.78.1
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
+  /vite/3.1.3:
+    resolution: {integrity: sha512-/3XWiktaopByM5bd8dqvHxRt5EEgRikevnnrpND0gRfNkrMrPaGGexhtLCzv15RcCMtV2CLw+BPas8YFeSG0KA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      less: '*'
+      sass: '*'
+      stylus: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      less:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      esbuild: 0.15.8
       postcss: 8.4.16
       resolve: 1.22.1
       rollup: 2.78.1

--- a/src/index.ts
+++ b/src/index.ts
@@ -548,8 +548,7 @@ export const renderHeadToString = (head: HeadClient): HTMLResult => {
   let bodyAttrs: HeadAttrs = {}
   let bodyTags: string[] = []
 
-  // by virtue of using this function, we are server-side rendering
-  // we need to tell the client that we've server rendered at this final node so hydration can happen in reverse
+  // tell the client that we've server rendered at this final node so that the DOM update can be done at the right time
   if (head._ssrHydrateFromNodeId >= 0) {
     htmlAttrs["data-head-ssr"] = head._ssrHydrateFromNodeId
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,8 @@ import {
   unref,
   shallowRef,
   getCurrentInstance,
+  computed,
+  markRaw,
 } from "vue"
 import {
   PROVIDE_KEY,
@@ -637,28 +639,13 @@ export const Head = /*@__PURE__*/ defineComponent({
   name: "Head",
 
   setup(_, { slots }) {
-    const head = injectHead()
-
-    let obj: Ref<HeadObjectPlain> | undefined
-
-    onBeforeUnmount(() => {
-      if (obj) {
-        head.removeHeadObjs(obj)
-        head.updateDOM()
-      }
-    })
-
+    const input = ref({})
+    // @ts-expect-error untyped vue transforms
+    useHead(computed(() => markRaw(input.value)))
     return () => {
       watchEffect(() => {
         if (!slots.default) return
-        if (obj) {
-          head.removeHeadObjs(obj)
-        }
-        obj = ref(vnodesToHeadObj(slots.default()))
-        head.addHeadObjs(obj)
-        if (IS_BROWSER) {
-          head.updateDOM()
-        }
+        input.value = vnodesToHeadObj(slots.default())
       })
       return null
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -445,18 +445,16 @@ export const useHead = (obj: MaybeRef<HeadObject>) => {
 
   head.addHeadObjs(headObj)
 
-  if (!IS_BROWSER) {
-    return
+  if (IS_BROWSER) {
+    watchEffect(() => {
+      head.updateDOM()
+    })
+
+    onBeforeUnmount(() => {
+      head.removeHeadObjs(headObj)
+      head.updateDOM()
+    })
   }
-
-  watchEffect(() => {
-    head.updateDOM()
-  })
-
-  onBeforeUnmount(() => {
-    head.removeHeadObjs(headObj)
-    head.updateDOM()
-  })
 }
 
 const tagToString = (tag: HeadTag) => {
@@ -618,6 +616,7 @@ export const Head = /*@__PURE__*/ defineComponent({
         head.updateDOM()
       }
     })
+
     return () => {
       watchEffect(() => {
         if (!slots.default) return
@@ -627,13 +626,11 @@ export const Head = /*@__PURE__*/ defineComponent({
         obj = ref(vnodesToHeadObj(slots.default()))
         head.addHeadObjs(obj)
 
-        if (!IS_BROWSER) {
-          return
+        if (IS_BROWSER) {
+          watchEffect(() => {
+            head.updateDOM()
+          })
         }
-
-        watchEffect(() => {
-          head.updateDOM()
-        })
       })
       return null
     }

--- a/tests/e2e/nuxt3/nuxt.test.ts
+++ b/tests/e2e/nuxt3/nuxt.test.ts
@@ -13,8 +13,9 @@ describe("e2e: nuxt 3", () => {
   it("basic", async () => {
     const html = await $fetch("/")
     const $ = load(html as string)
-    expect($("title").text()).equals("Home | Nuxt")
-    expect($('meta[name="head:count"]').attr("content")).toMatch("4")
+    expect($("title").text()).equals("Home | Nuxt | Title Site")
+    expect($('meta[name="head:count"]').attr("content")).toMatch("2")
+    expect($('html').attr("data-head-ssr")).toMatch("7")
     await expectNoClientErrors("/")
   })
 })

--- a/tests/e2e/nuxt3/nuxt.test.ts
+++ b/tests/e2e/nuxt3/nuxt.test.ts
@@ -15,7 +15,6 @@ describe("e2e: nuxt 3", () => {
     const $ = load(html as string)
     expect($("title").text()).equals("Home | Nuxt | Title Site")
     expect($('meta[name="head:count"]').attr("content")).toMatch("2")
-    expect($("html").attr("data-head-ssr")).toMatch("7")
     await expectNoClientErrors("/")
   })
 })

--- a/tests/e2e/nuxt3/nuxt.test.ts
+++ b/tests/e2e/nuxt3/nuxt.test.ts
@@ -15,7 +15,7 @@ describe("e2e: nuxt 3", () => {
     const $ = load(html as string)
     expect($("title").text()).equals("Home | Nuxt | Title Site")
     expect($('meta[name="head:count"]').attr("content")).toMatch("2")
-    expect($('html').attr("data-head-ssr")).toMatch("7")
+    expect($("html").attr("data-head-ssr")).toMatch("7")
     await expectNoClientErrors("/")
   })
 })

--- a/tests/e2e/vite-ssr/vite-ssr.test.ts
+++ b/tests/e2e/vite-ssr/vite-ssr.test.ts
@@ -58,11 +58,13 @@ describe("e2e: vite ssr", async () => {
       })
       return head.headTags
     }
-    expect((await getHeadTags()).find(t => t.tag === 'title')!.props.children)
-      .toMatchInlineSnapshot('"0 | @vueuse/head"')
+    expect(
+      (await getHeadTags()).find((t) => t.tag === "title")!.props.children,
+    ).toMatchInlineSnapshot('"0 | @vueuse/head"')
     await page.click("button")
-    expect((await getHeadTags()).find(t => t.tag === 'title')!.props.children)
-      .toMatchInlineSnapshot('"1 | @vueuse/head"')
+    expect(
+      (await getHeadTags()).find((t) => t.tag === "title")!.props.children,
+    ).toMatchInlineSnapshot('"1 | @vueuse/head"')
   })
 
   test("body script", async () => {

--- a/tests/toggle-dom-render.test.ts
+++ b/tests/toggle-dom-render.test.ts
@@ -1,0 +1,68 @@
+import { computed, createSSRApp, ref } from "vue"
+import { createHead, useHead } from "../src"
+import { JSDOM } from "jsdom"
+import { renderToString } from "@vue/server-renderer"
+import { injectHead } from "@vueuse/head"
+
+describe("toggle dom render", () => {
+  test("basic", async () => {
+    const head = createHead()
+    head.addHeadObjs(
+      computed(() => ({
+        title: "test",
+      })),
+    )
+
+    head._pauseDOMUpdates.value = true
+
+    const dom = new JSDOM(
+      "<!DOCTYPE html><html><head></head><body></body></html>",
+    )
+
+    head.updateDOM(dom.window.document)
+
+    expect(dom.window.document.head.innerHTML).toMatchInlineSnapshot('""')
+
+    head._pauseDOMUpdates.value = false
+
+    head.updateDOM(dom.window.document)
+
+    expect(dom.window.document.head.innerHTML).toMatchInlineSnapshot(
+      '"<title>test</title>"',
+    )
+  })
+
+  test("vue", async () => {
+    const head = createHead()
+    const app = createSSRApp({
+      setup() {
+        const client = injectHead()
+        client._pauseDOMUpdates.value = true
+        const title = ref("")
+        useHead({
+          title,
+        })
+        const dom = new JSDOM(
+          "<!DOCTYPE html><html><head></head><body></body></html>",
+        )
+
+        head.updateDOM(dom.window.document)
+
+        expect(dom.window.document.head.innerHTML).toMatchInlineSnapshot('""')
+
+        client._pauseDOMUpdates.value = false
+        title.value = "hello"
+
+        head.updateDOM(dom.window.document)
+
+        expect(dom.window.document.head.innerHTML).toMatchInlineSnapshot(
+          '"<title>hello</title>"',
+        )
+
+        return () => "<div>hi</div>"
+      },
+    })
+    app.use(head)
+    await renderToString(app)
+  })
+})

--- a/tests/toggle-dom-render.test.ts
+++ b/tests/toggle-dom-render.test.ts
@@ -1,8 +1,7 @@
 import { computed, createSSRApp, ref } from "vue"
-import { createHead, useHead } from "../src"
+import { createHead, useHead, injectHead } from "../src"
 import { JSDOM } from "jsdom"
 import { renderToString } from "@vue/server-renderer"
-import { injectHead } from "@vueuse/head"
 
 describe("toggle dom render", () => {
   test("basic", async () => {


### PR DESCRIPTION
## Problem

See #98, #75, https://github.com/nuxt/framework/issues/6183

## Solution

Simple boolean ref for toggling the DOM updates.

The `updateDOM` calls will automatically be re-done when unpaused as they are wrapped in a `watchEffects`.

In Nuxt this allows you to wait for `<Suspense>` to resolve with the below code. I don't think it's possible to add a way for `@vueuse/head` to handle this generically without introducing a router dependency.

```ts
nuxtApp.hooks.hookOnce("page:finish", () => {
  // start pausing DOM updates when route changes (trigger immediately)
  useRouter().beforeEach(() => {
    head._pauseDOMUpdates.value = true
  })

  // watch for new route before unpausing dom updates (triggered after suspense resolved)
  watch(useRoute(), () => {
    head._pauseDOMUpdates.value = false
  })
})
```


## Other notes

The Nuxt example module now completely removes the native meta module in favour of our custom implementation, which makes testing changes like this simpler.
