### PR TITLE
fix: use proper encoding for attr name / val pairs

### DIFF
--- a/src/stringify-attrs.ts
+++ b/src/stringify-attrs.ts
@@ -7,7 +7,11 @@
  * @see https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
  */
 export const stringifyAttrName = (str: string) =>
-  str.replace(/[\s"'><\/=]/g, "")
+  str
+    // replace special characters
+    .replace(/[\s"'><\/=]/g, "")
+    // replace noncharacters (except for - and _)
+    .replace(/[^a-zA-Z0-9_-]/g, "")
 /**
  * Double-quoted attribute value must not contain any literal U+0022 QUOTATION MARK characters ("). Including
  * < and > will cause HTML to be invalid.

--- a/src/stringify-attrs.ts
+++ b/src/stringify-attrs.ts
@@ -1,13 +1,23 @@
-// MIT licensed: modified from https://github.com/sindresorhus/stringify-attributes/blob/6e437781d684d9e61a6979a8dd2407a81dd3f4ed/index.js
-const htmlEscape = (str: string) =>
-  str
-    .replace(/&/g, "&amp;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
+/**
+ * Attribute names must consist of one or more characters other than controls, U+0020 SPACE, U+0022 ("), U+0027 ('),
+ * U+003E (>), U+002F (/), U+003D (=), and noncharacters.
+ *
+ * We strip them for the attribute name as they shouldn't exist even if encoded.
+ *
+ * @see https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
+ */
+export const stringifyAttrName = (str: string) =>
+  str.replace(/[\s"'><\/=]/g, "")
+/**
+ * Double-quoted attribute value must not contain any literal U+0022 QUOTATION MARK characters ("). Including
+ * < and > will cause HTML to be invalid.
+ *
+ * @see https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
+ */
+export const stringifyAttrValue = (str: string) =>
+  str.replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
 
-export const stringifyAttrs = (attributes: any) => {
+export const stringifyAttrs = (attributes: Record<string, any>) => {
   const handledAttributes = []
 
   for (let [key, value] of Object.entries(attributes)) {
@@ -19,10 +29,10 @@ export const stringifyAttrs = (attributes: any) => {
       continue
     }
 
-    let attribute = htmlEscape(key)
+    let attribute = stringifyAttrName(key)
 
     if (value !== true) {
-      attribute += `="${htmlEscape(String(value))}"`
+      attribute += `="${stringifyAttrValue(String(value))}"`
     }
 
     handledAttributes.push(attribute)

--- a/tests/encoding.test.ts
+++ b/tests/encoding.test.ts
@@ -2,18 +2,37 @@ import { computed } from "vue"
 import { createHead, renderHeadToString } from "../src"
 
 describe("encoding", () => {
+  it("jailbreak", async () => {
+    const head = createHead()
+    head.addHeadObjs(
+      computed(() => ({
+        meta: [
+          {
+            ['> console.alert("test")']:
+              "<style>body { background: red; }</style>",
+          },
+        ],
+      })),
+    )
+    const { headTags } = renderHeadToString(head)
+    // valid html (except for the tag name)
+    expect(headTags).toMatchInlineSnapshot(
+      '"<meta consolealerttest=\\"&lt;style&gt;body { background: red; }&lt;/style&gt;\\"><meta name=\\"head:count\\" content=\\"1\\">"',
+    )
+  })
+
   it("google maps", async () => {
     const head = createHead()
     head.addHeadObjs(
+      // @ts-expect-error computed issue
       computed(() => ({
         script: [
           {
             src: "https://polyfill.io/v3/polyfill.min.js?features=default",
-            defer: false,
-            body: false,
           },
           {
             src: "https://maps.googleapis.com/maps/api/js?key=AIzaSyB41DRUbKWJHPxaFjMAwdrzWzbVKartNGg&callback=initMap&v=weekly",
+            ["data-key"]: "AIzaSyD9hQ0Z7Y9XQX8Zjwq7Q9Z2YQ9Z2YQ9Z2Y",
             defer: true,
             body: true,
           },
@@ -27,11 +46,11 @@ describe("encoding", () => {
     )
     // valid html
     expect(bodyTags).toMatchInlineSnapshot(
-      '"<script src=\\"https://maps.googleapis.com/maps/api/js?key=AIzaSyB41DRUbKWJHPxaFjMAwdrzWzbVKartNGg&callback=initMap&v=weekly\\" defer data-meta-body=\\"true\\"></script>"',
+      '"<script src=\\"https://maps.googleapis.com/maps/api/js?key=AIzaSyB41DRUbKWJHPxaFjMAwdrzWzbVKartNGg&callback=initMap&v=weekly\\" data-key=\\"AIzaSyD9hQ0Z7Y9XQX8Zjwq7Q9Z2YQ9Z2YQ9Z2Y\\" defer data-meta-body=\\"true\\"></script>"',
     )
   })
 
-  // Note: This should be fixed in a seperate PR, possibly don't allow scripts without using useHeadRaw
+  // Note: This should be fixed in a separate PR, possibly don't allow scripts without using useHeadRaw
   it("xss", async () => {
     const externalApiHeadData = {
       script: [

--- a/tests/encoding.test.ts
+++ b/tests/encoding.test.ts
@@ -1,0 +1,50 @@
+import { computed } from "vue"
+import { createHead, renderHeadToString } from "../src"
+
+describe("encoding", () => {
+  it("google maps", async () => {
+    const head = createHead()
+    head.addHeadObjs(
+      computed(() => ({
+        script: [
+          {
+            src: "https://polyfill.io/v3/polyfill.min.js?features=default",
+            defer: false,
+            body: false,
+          },
+          {
+            src: "https://maps.googleapis.com/maps/api/js?key=AIzaSyB41DRUbKWJHPxaFjMAwdrzWzbVKartNGg&callback=initMap&v=weekly",
+            defer: true,
+            body: true,
+          },
+        ],
+      })),
+    )
+    const { headTags, bodyTags } = renderHeadToString(head)
+    // valid html
+    expect(headTags).toMatchInlineSnapshot(
+      '"<script src=\\"https://polyfill.io/v3/polyfill.min.js?features=default\\"></script><meta name=\\"head:count\\" content=\\"1\\">"',
+    )
+    // valid html
+    expect(bodyTags).toMatchInlineSnapshot(
+      '"<script src=\\"https://maps.googleapis.com/maps/api/js?key=AIzaSyB41DRUbKWJHPxaFjMAwdrzWzbVKartNGg&callback=initMap&v=weekly\\" defer data-meta-body=\\"true\\"></script>"',
+    )
+  })
+
+  // Note: This should be fixed in a seperate PR, possibly don't allow scripts without using useHeadRaw
+  it("xss", async () => {
+    const externalApiHeadData = {
+      script: [
+        {
+          children: 'console.alert("xss")',
+        },
+      ],
+    }
+    const head = createHead()
+    head.addHeadObjs(computed(() => externalApiHeadData))
+    const { headTags } = renderHeadToString(head)
+    expect(headTags).toMatchInlineSnapshot(
+      '"<script>console.alert(\\"xss\\")</script><meta name=\\"head:count\\" content=\\"1\\">"',
+    )
+  })
+})


### PR DESCRIPTION
## Issue

See https://github.com/vueuse/head/issues/59

The encoding is too aggressive. it assumes that the value component of the attribute isn't quoted.

> Properly quoted attributes can only be escaped with the corresponding quote.

## Solution

Separately encode the attribute name more aggressively, stripping any unsupported characters. 

For attribute values, we encode the " character to avoid escaping, and we use encode <> otherwise they will cause the HTML to be invalid.

If the intention of this encoding was to avoid XSS issues, then it's kind of pointless (see second test example). If we're simply encoding to avoid accidental scope scapes then this should be fine.