### PR TITLE
fix: simplify tag dedupe logic

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -318,7 +318,9 @@ export const createHead = (initHeadObject?: MaybeRef<HeadObjectPlain>) => {
         const tags = headObjToTags(unref(objs))
         tags.forEach((tag, tagIdx) => {
           // used to restore the order after deduping
-          tag._position = headObjectIdx * 10 + tagIdx
+          // a large number is needed otherwise the position will potentially duplicate (this support 10k tags)
+          // ideally we'd use the total tag count but this is too hard to calculate with the current reactivity
+          tag._position = headObjectIdx * 10000 + tagIdx
           // resolve titles
           if (titleTemplate && tag.tag === "title") {
             tag.props.children = renderTemplate(

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,8 +96,8 @@ const tagDedupeKey = <T extends HeadTag>(tag: T) => {
       value = props[n]
     }
     if (value !== undefined) {
-      // for example: name-description
-      return `${n}-${value}`
+      // for example: meta-name-description
+      return `${tagName}-${n}-${value}`
     }
   }
   return false
@@ -306,7 +306,7 @@ export const createHead = (initHeadObject?: MaybeRef<HeadObjectPlain>) => {
      * Get deduped tags
      */
     get headTags() {
-      const tags: HeadTag[] = []
+      const deduped: HeadTag[] = []
       const deduping: Record<string, HeadTag> = {}
 
       const titleTemplate = allHeadObjs
@@ -331,15 +331,15 @@ export const createHead = (initHeadObject?: MaybeRef<HeadObjectPlain>) => {
           if (dedupeKey) {
             deduping[dedupeKey] = tag
           } else {
-            tags.push(tag)
+            deduped.push(tag)
           }
         })
       })
 
       // add the entries we were deduping
-      tags.push(...Object.values(deduping))
+      deduped.push(...Object.values(deduping))
       // ensure their original positions are kept
-      return tags.sort((a, b) => a._position! - b._position!)
+      return deduped.sort((a, b) => a._position! - b._position!)
     },
 
     addHeadObjs(objs) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,6 +96,7 @@ const tagDedupeKey = <T extends HeadTag>(tag: T) => {
       value = props[n]
     }
     if (value !== undefined) {
+      // for example: name-description
       return `${n}-${value}`
     }
   }
@@ -305,7 +306,7 @@ export const createHead = (initHeadObject?: MaybeRef<HeadObjectPlain>) => {
      * Get deduped tags
      */
     get headTags() {
-      const deduped: HeadTag[] = []
+      const tags: HeadTag[] = []
       const deduping: Record<string, HeadTag> = {}
 
       const titleTemplate = allHeadObjs
@@ -316,6 +317,7 @@ export const createHead = (initHeadObject?: MaybeRef<HeadObjectPlain>) => {
       allHeadObjs.forEach((objs, headObjectIdx) => {
         const tags = headObjToTags(unref(objs))
         tags.forEach((tag, tagIdx) => {
+          // used to restore the order after deduping
           tag._position = headObjectIdx * 10 + tagIdx
           // resolve titles
           if (titleTemplate && tag.tag === "title") {
@@ -324,21 +326,20 @@ export const createHead = (initHeadObject?: MaybeRef<HeadObjectPlain>) => {
               tag.props.children,
             )
           }
-
           // Remove tags with the same key
           const dedupeKey = tagDedupeKey(tag)
           if (dedupeKey) {
             deduping[dedupeKey] = tag
           } else {
-            deduped.push(tag)
+            tags.push(tag)
           }
         })
       })
 
       // add the entries we were deduping
-      deduped.push(...Object.values(deduping))
-
-      return deduped.sort((a, b) => a._position! - b._position!)
+      tags.push(...Object.values(deduping))
+      // ensure their original positions are kept
+      return tags.sort((a, b) => a._position! - b._position!)
     },
 
     addHeadObjs(objs) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ export type HeadTag = {
     RendersInnerContent & {
       [k: string]: any
     }
+  _position?: number
 }
 
 export type HeadClient = {
@@ -67,7 +68,7 @@ export interface HTMLResult {
   readonly bodyTags: string
 }
 
-const getTagDeduper = <T extends HeadTag>(tag: T) => {
+const tagDedupeKey = <T extends HeadTag>(tag: T) => {
   // only meta, base and script tags will be deduped
   if (!["meta", "base", "script", "link"].includes(tag.tag)) {
     return false
@@ -75,15 +76,15 @@ const getTagDeduper = <T extends HeadTag>(tag: T) => {
   const { props, tag: tagName } = tag
   // must only be a single base so we always dedupe
   if (tagName === "base") {
-    return true
+    return "base"
   }
   // support only a single canonical
   if (tagName === "link" && props.rel === "canonical") {
-    return { propValue: "canonical" }
+    return "canonical"
   }
   // must only be a single charset
   if (props.charset) {
-    return { propKey: "charset" }
+    return "charset"
   }
   const name = ["key", "id", "name", "property", "http-equiv"]
   for (const n of name) {
@@ -95,7 +96,7 @@ const getTagDeduper = <T extends HeadTag>(tag: T) => {
       value = props[n]
     }
     if (value !== undefined) {
-      return { propValue: n }
+      return `${n}-${value}`
     }
   }
   return false
@@ -305,56 +306,18 @@ export const createHead = (initHeadObject?: MaybeRef<HeadObjectPlain>) => {
      */
     get headTags() {
       const deduped: HeadTag[] = []
+      const deduping: Record<string, HeadTag> = {}
 
       const titleTemplate = allHeadObjs
         .map((i) => unref(i).titleTemplate)
         .reverse()
         .find((i) => i != null)
 
-      allHeadObjs.forEach((objs) => {
+      allHeadObjs.forEach((objs, headObjectIdx) => {
         const tags = headObjToTags(unref(objs))
-        tags.forEach((tag) => {
-          // Remove tags with the same key
-          const dedupe = getTagDeduper(tag)
-          if (dedupe) {
-            let index = -1
-
-            for (let i = 0; i < deduped.length; i++) {
-              const prev = deduped[i]
-              // only if the tags match
-              if (prev.tag !== tag.tag) {
-                continue
-              }
-              // dedupe based on tag, for example <base>
-              if (dedupe === true) {
-                index = i
-              }
-              // dedupe based on property key value, for example <meta name="description">
-              else if (
-                dedupe.propValue &&
-                unref(prev.props[dedupe.propValue]) ===
-                  unref(tag.props[dedupe.propValue])
-              ) {
-                index = i
-              }
-              // dedupe based on property keys, for example <meta charset="utf-8">
-              else if (
-                dedupe.propKey &&
-                prev.props[dedupe.propKey] &&
-                tag.props[dedupe.propKey]
-              ) {
-                index = i
-              }
-              if (index !== -1) {
-                break
-              }
-            }
-
-            if (index !== -1) {
-              deduped.splice(index, 1)
-            }
-          }
-
+        tags.forEach((tag, tagIdx) => {
+          tag._position = headObjectIdx * 10 + tagIdx
+          // resolve titles
           if (titleTemplate && tag.tag === "title") {
             tag.props.children = renderTemplate(
               titleTemplate,
@@ -362,11 +325,20 @@ export const createHead = (initHeadObject?: MaybeRef<HeadObjectPlain>) => {
             )
           }
 
-          deduped.push(tag)
+          // Remove tags with the same key
+          const dedupeKey = tagDedupeKey(tag)
+          if (dedupeKey) {
+            deduping[dedupeKey] = tag
+          } else {
+            deduped.push(tag)
+          }
         })
       })
 
-      return deduped
+      // add the entries we were deduping
+      deduped.push(...Object.values(deduping))
+
+      return deduped.sort((a, b) => a._position! - b._position!)
     },
 
     addHeadObjs(objs) {

--- a/tests/dedupe.test.ts
+++ b/tests/dedupe.test.ts
@@ -174,7 +174,7 @@ describe("dedupe", () => {
     )
   })
 
-  test.only("doesn't dedupe over tag types", async () => {
+  test("doesn't dedupe over tag types", async () => {
     const head = createHead()
     head.addHeadObjs(
       computed(() => ({

--- a/tests/dedupe.test.ts
+++ b/tests/dedupe.test.ts
@@ -173,4 +173,24 @@ describe("dedupe", () => {
       '"<link rel=\\"icon\\" href=\\"/favicon.ico\\"><link rel=\\"canonical\\" href=\\"https://mydomain.me\\"><meta name=\\"head:count\\" content=\\"2\\">"',
     )
   })
+
+  test.only("doesn't dedupe over tag types", async () => {
+    const head = createHead()
+    head.addHeadObjs(
+      computed(() => ({
+        meta: [{
+          key: 'icon',
+          name: 'description',
+          content: 'test'
+        }],
+        link: [
+          { rel: "icon", href: "/favicon.ico", key: 'icon' },
+        ],
+      })),
+    )
+    const { headTags } = renderHeadToString(head)
+    expect(headTags).toMatchInlineSnapshot(
+      '"<meta name=\\"description\\" content=\\"test\\"><link rel=\\"icon\\" href=\\"/favicon.ico\\"><meta name=\\"head:count\\" content=\\"2\\">"',
+    )
+  })
 })

--- a/tests/dedupe.test.ts
+++ b/tests/dedupe.test.ts
@@ -157,4 +157,20 @@ describe("dedupe", () => {
     const { headTags } = renderHeadToString(head)
     expect(headTags.split("http-equiv").length === 2).toBeTruthy()
   })
+
+  test("issue #104", async () => {
+    const head = createHead()
+    head.addHeadObjs(
+      computed(() => ({
+        link: [
+          { rel: "icon", href: "/favicon.ico" }, // <-- this and,
+          { rel: "canonical", href: "https://mydomain.me" }, // <-- this. Please reverse the order to be sure.
+        ],
+      })),
+    )
+    const { headTags } = renderHeadToString(head)
+    expect(headTags).toMatchInlineSnapshot(
+      '"<link rel=\\"icon\\" href=\\"/favicon.ico\\"><link rel=\\"canonical\\" href=\\"https://mydomain.me\\"><meta name=\\"head:count\\" content=\\"2\\">"',
+    )
+  })
 })


### PR DESCRIPTION
## Issue

Fixes https://github.com/vueuse/head/issues/104

The broader issue is that the deduping logic has more going on than it needs to.

## Solution

For any given tag we need to generate a string of the dedupe key and insert it into a record to dedupe.

The only issue with this is we lose the order in which the tag is being inserted, so we must introduce a `_position` value to the tag to place it back in the correct spot.