### PR TITLE
chore: migrate to eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+dist
+node_modules
+examples/vite-ssr
+tests/e2e/vite-ssr

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,0 @@
-{
-  "extends": "@antfu"
-}

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "@antfu"
+}

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,11 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    node: true,
+  },
+  extends: '@antfu/eslint-config',
+  rules: {
+    'vue/one-component-per-file': 'off'
+  },
+}

--- a/.github/workflows/export-sizes.yml
+++ b/.github/workflows/export-sizes.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: https://registry.npmjs.org/
-          cache: "pnpm"
+          cache: pnpm
       - uses: antfu/export-size-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
+      - 'v*'
 
 jobs:
   release:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    if: "!contains(github.event.head_commit.message, 'ci skip')"
+    if: '!contains(github.event.head_commit.message, ''ci skip'')'
 
     strategy:
       matrix:

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,1 +1,0 @@
-"@egoist/prettier-config"

--- a/examples/nuxt3/app.vue
+++ b/examples/nuxt3/app.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { useHead } from "#head"
+import { useHead } from '#head'
 
 useHead({
-  title: "Title",
-  titleTemplate: (title) => `${title} | Title Site`,
+  title: 'Title',
+  titleTemplate: title => `${title} | Title Site`,
 })
 </script>
+
 <template>
   <div>
     <NuxtPage />

--- a/examples/nuxt3/components/ModifyTitle.vue
+++ b/examples/nuxt3/components/ModifyTitle.vue
@@ -2,12 +2,13 @@
 const props = defineProps<{
   title: string
 }>()
-await new Promise((resolve) => setTimeout(resolve, 1000))
+await new Promise(resolve => setTimeout(resolve, 1000))
 
 useHead({
   title: computed(() => props.title),
 })
 </script>
+
 <template>
   <div>final title test</div>
 </template>

--- a/examples/nuxt3/nuxt.config.ts
+++ b/examples/nuxt3/nuxt.config.ts
@@ -1,41 +1,41 @@
-import { defineNuxtConfig } from "nuxt/config"
-import { fileURLToPath } from "url"
-import { addPlugin } from "@nuxt/kit"
-import { resolve } from "pathe"
+import { fileURLToPath } from 'url'
+import { defineNuxtConfig } from 'nuxt/config'
+import { addPlugin } from '@nuxt/kit'
+import { resolve } from 'pathe'
 
-const runtimeDir = fileURLToPath(new URL("./runtime", import.meta.url))
-const rootDir = fileURLToPath(new URL("../../", import.meta.url))
+const runtimeDir = fileURLToPath(new URL('./runtime', import.meta.url))
+const rootDir = fileURLToPath(new URL('../../', import.meta.url))
 
 // https://v3.nuxtjs.org/api/configuration/nuxt.config
 export default defineNuxtConfig({
   alias: {
-    "@vueuse/head": `${rootDir}/src`,
+    '@vueuse/head': `${rootDir}/src`,
   },
   app: {
     head: {
-      title: "default title",
+      title: 'default title',
     },
   },
   workspaceDir: rootDir,
   hooks: {
-    "modules:before": async ({ nuxt }) => {
+    'modules:before': async ({ nuxt }) => {
       const newModules = nuxt.options._modules
       // remove the nuxt meta (head) module
       for (const k in newModules) {
-        if (typeof newModules[k] === "function") {
-          if ((await newModules[k].getMeta()).name === "meta") {
+        if (typeof newModules[k] === 'function') {
+          if ((await newModules[k].getMeta()).name === 'meta') {
             // we can't use an undefined key so use a duplicate
-            newModules[k] = "@nuxt/telemetry"
+            newModules[k] = '@nuxt/telemetry'
           }
         }
       }
       nuxt.options._modules = newModules
     },
-    "modules:done"({ nuxt }) {
+    'modules:done': function ({ nuxt }) {
       // Replace #head alias
-      nuxt.options.alias["#head"] = runtimeDir
+      nuxt.options.alias['#head'] = runtimeDir
 
-      addPlugin({ src: resolve(runtimeDir, "plugin") }, { append: true })
+      addPlugin({ src: resolve(runtimeDir, 'plugin') }, { append: true })
 
       nuxt.options.build.transpile.push(runtimeDir)
     },

--- a/examples/nuxt3/pages/index.vue
+++ b/examples/nuxt3/pages/index.vue
@@ -1,29 +1,32 @@
 <script lang="ts" setup>
-import { useHead } from "#head"
+import { useHead } from '#head'
 
 const page = ref({
-  title: "Home",
-  description: "Home page description",
-  image: "https://nuxtjs.org/meta_400.png",
+  title: 'Home',
+  description: 'Home page description',
+  image: 'https://nuxtjs.org/meta_400.png',
 })
 
 useHead({
   title: computed(() => `${page.value.title} | Nuxt`),
   meta: [
     {
-      name: "description",
+      name: 'description',
       content: computed(() => page.value.description),
     },
     {
-      property: "og:image",
+      property: 'og:image',
       content: computed(() => page.value.image),
     },
   ],
 })
 </script>
+
 <template>
   <div>
     <h1>Index</h1>
-    <nuxt-link to="/second">second page</nuxt-link>
+    <nuxt-link to="/second">
+      second page
+    </nuxt-link>
   </div>
 </template>

--- a/examples/nuxt3/pages/second.vue
+++ b/examples/nuxt3/pages/second.vue
@@ -1,38 +1,43 @@
 <script lang="ts" setup>
-await new Promise((resolve) => setTimeout(resolve, 1000))
+await new Promise(resolve => setTimeout(resolve, 1000))
 
-const title = ref("Intermediately title with 1s delay")
+const title = ref('Intermediately title with 1s delay')
 
 useHead({
   title,
   bodyAttrs: {
-    class: "new-bg",
+    class: 'new-bg',
   },
   style: [
     // this is an example of the side effects of this rendering strategy
     // this style won't be hydrated at all
     {
       children: `.new-bg { background-color: lemonchiffon; } h2 { color: ${
-        process.server ? "red" : "lime"
+        process.server ? 'red' : 'lime'
       }; }`,
     },
   ],
 })
 
 const changeTitle = () => {
-  title.value = "Intermediately title updated"
+  title.value = 'Intermediately title updated'
 }
 
 const finalTitle = computed(() => {
-  return title.value.replace("Intermediately", "Final")
+  return title.value.replace('Intermediately', 'Final')
 })
 </script>
+
 <template>
   <div>
     <h2>second page</h2>
     <p>has a 1 second delay on rendering</p>
     <ModifyTitle :title="finalTitle" />
-    <button @click="changeTitle">change title</button>
-    <nuxt-link to="/">first page</nuxt-link>
+    <button @click="changeTitle">
+      change title
+    </button>
+    <nuxt-link to="/">
+      first page
+    </nuxt-link>
   </div>
 </template>

--- a/examples/nuxt3/runtime/index.ts
+++ b/examples/nuxt3/runtime/index.ts
@@ -1,5 +1,5 @@
-import type { HeadObject } from "@vueuse/head"
-import { useNuxtApp } from "#app"
+import type { HeadObject } from '@vueuse/head'
+import { useNuxtApp } from '#app'
 
 export type MetaObject = HeadObject
 

--- a/examples/nuxt3/runtime/plugin.ts
+++ b/examples/nuxt3/runtime/plugin.ts
@@ -1,16 +1,15 @@
-import { createHead, renderHeadToString } from "@vueuse/head"
+import { createHead, renderHeadToString } from '@vueuse/head'
+import type { ComputedGetter } from 'vue'
 import {
   computed,
+  getCurrentInstance,
+  onBeforeUnmount,
   ref,
   watchEffect,
-  onBeforeUnmount,
-  getCurrentInstance,
-  ComputedGetter,
-} from "vue"
-import defu from "defu"
-import type { MetaObject } from "."
-import { defineNuxtPlugin, useRoute } from "#app"
-import { useRouter, watch } from "#imports"
+} from 'vue'
+import defu from 'defu'
+import type { MetaObject } from '.'
+import { defineNuxtPlugin } from '#app'
 
 // Note: This is just a copy of Nuxt's internal head plugin with modifications made for this issue
 
@@ -20,7 +19,7 @@ export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.vueApp.use(head)
 
   const headReady = ref(false)
-  nuxtApp.hooks.hookOnce("app:mounted", () => {
+  nuxtApp.hooks.hookOnce('app:mounted', () => {
     watchEffect(() => {
       head.updateDOM()
     })
@@ -31,30 +30,28 @@ export default defineNuxtPlugin((nuxtApp) => {
     const meta = ref<MetaObject>(_meta)
     const headObj = computed(() => {
       const overrides: MetaObject = { meta: [] }
-      if (meta.value.charset) {
-        overrides.meta!.push({ key: "charset", charset: meta.value.charset })
-      }
-      if (meta.value.viewport) {
-        overrides.meta!.push({ name: "viewport", content: meta.value.viewport })
-      }
+      if (meta.value.charset)
+        overrides.meta!.push({ key: 'charset', charset: meta.value.charset })
+
+      if (meta.value.viewport)
+        overrides.meta!.push({ name: 'viewport', content: meta.value.viewport })
+
       return defu(overrides, meta.value)
     })
     head.addHeadObjs(headObj as any)
 
-    if (process.server) {
+    if (process.server)
       return
-    }
 
-    if (headReady) {
+    if (headReady.value) {
       watchEffect(() => {
         head.updateDOM()
       })
     }
 
     const vm = getCurrentInstance()
-    if (!vm) {
+    if (!vm)
       return
-    }
 
     onBeforeUnmount(() => {
       head.removeHeadObjs(headObj as any)

--- a/examples/vite-ssr/Contact.vue
+++ b/examples/vite-ssr/Contact.vue
@@ -1,26 +1,30 @@
 <script setup>
-import { ref } from "vue"
-import { Head } from "../../src"
+import { ref } from 'vue'
+import { Head } from '../../src'
 
 const count = ref(0)
 
-const style = `button {color: red}`
+const style = 'button {color: red}'
 </script>
 
 <template>
   <Head>
     <title>{{ count }}</title>
-    <html lang="en"></html>
-    <body class="body"></body>
-    <meta name="description" content="desc" />
+    <html lang="en" />
+    <body class="body" />
+    <meta name="description" content="desc">
     <component is="style">
-      body { background: lightgreen; } {{ style }}</component
-    >
+      body { background: lightgreen; } {{ style }}
+    </component>
   </Head>
 
-  <router-link to="/">Back Home</router-link>
+  <router-link to="/">
+    Back Home
+  </router-link>
 
-  <hr />
+  <hr>
 
-  <button @click="count++">{{ count }}</button>
+  <button @click="count++">
+    {{ count }}
+  </button>
 </template>

--- a/examples/vite-ssr/app.tsx
+++ b/examples/vite-ssr/app.tsx
@@ -1,13 +1,13 @@
-import { createSSRApp, ref, h, defineComponent, computed } from "vue"
+import { computed, createSSRApp, defineComponent, ref } from 'vue'
 import {
-  createRouter,
-  createWebHistory,
-  createMemoryHistory,
   RouterLink,
   RouterView,
-} from "vue-router"
-import { createHead, useHead } from "../../src"
-import Contact from "./Contact.vue"
+  createMemoryHistory,
+  createRouter,
+  createWebHistory,
+} from 'vue-router'
+import { createHead, useHead } from '../../src'
+import Contact from './Contact.vue'
 
 export const createApp = () => {
   const Counter = defineComponent({
@@ -15,8 +15,8 @@ export const createApp = () => {
       const count = ref(0)
       useHead({
         title: computed(() => `count: ${count.value}`),
-        script: [{ children: 'console.log("a")', key: "a" }],
-        link: [{ href: "/foo", rel: "stylesheet" }],
+        script: [{ children: 'console.log("a")', key: 'a' }],
+        link: [{ href: '/foo', rel: 'stylesheet' }],
       })
       return () => (
         <button
@@ -33,43 +33,43 @@ export const createApp = () => {
 
   const Home = defineComponent({
     setup() {
-      const title = ref("Home")
+      const title = ref('Home')
       useHead({
         title,
-        base: { href: "/" },
-        style: [{ children: `body {background: salmon}` }],
+        base: { href: '/' },
+        style: [{ children: 'body {background: salmon}' }],
         htmlAttrs: {
-          lang: "en",
+          lang: 'en',
         },
-        noscript: [{ children: "This app requires javascript to work" }],
+        noscript: [{ children: 'This app requires javascript to work' }],
         meta: [
           {
-            name: "description",
-            content: "desc",
+            name: 'description',
+            content: 'desc',
           },
           {
-            name: "description",
-            content: "desc 2",
+            name: 'description',
+            content: 'desc 2',
           },
           {
-            property: "og:locale:alternate",
-            content: "fr",
-            key: "fr",
+            property: 'og:locale:alternate',
+            content: 'fr',
+            key: 'fr',
           },
           {
-            property: "og:locale:alternate",
-            content: "zh",
-            key: "zh",
+            property: 'og:locale:alternate',
+            content: 'zh',
+            key: 'zh',
           },
           {
-            name: "custom-priority",
-            content: "of 1",
+            name: 'custom-priority',
+            content: 'of 1',
             renderPriority: 1,
           },
         ],
         script: [
           {
-            children: `console.log('hi')`,
+            children: 'console.log(\'hi\')',
             body: true,
           },
         ],
@@ -77,12 +77,12 @@ export const createApp = () => {
       return () => (
         <div>
           <h1>Home</h1>
-          <RouterLink to="/about">About</RouterLink>{" "}
+          <RouterLink to="/about">About</RouterLink>{' '}
           <RouterLink to="/contact">Contact</RouterLink>
           <hr />
           <button
             class="change-home-title"
-            onClick={() => (title.value = "new title")}
+            onClick={() => (title.value = 'new title')}
           >
             Change home title (not really)
           </button>
@@ -95,8 +95,8 @@ export const createApp = () => {
   const About = defineComponent({
     setup() {
       useHead({
-        title: "About",
-        titleTemplate: "%s | About Template",
+        title: 'About',
+        titleTemplate: '%s | About Template',
       })
       return () => (
         <div>
@@ -111,20 +111,20 @@ export const createApp = () => {
     history: import.meta.env.SSR ? createMemoryHistory() : createWebHistory(),
     routes: [
       {
-        path: "/",
+        path: '/',
         component: Home,
       },
       {
-        path: "/about",
+        path: '/about',
         component: About,
       },
       {
-        path: "/contact",
+        path: '/contact',
         component: Contact,
       },
       {
-        path: "/ssr/dedup",
-        component: () => import("./pages/ssr/dedup.vue"),
+        path: '/ssr/dedup',
+        component: () => import('./pages/ssr/dedup.vue'),
       },
     ],
   })
@@ -134,8 +134,8 @@ export const createApp = () => {
       useHead({
         meta: [
           {
-            name: "global-meta",
-            content: "some global meta tag",
+            name: 'global-meta',
+            content: 'some global meta tag',
           },
         ],
       })
@@ -144,7 +144,7 @@ export const createApp = () => {
   })
 
   const head = createHead({
-    titleTemplate: "%s | @vueuse/head",
+    titleTemplate: '%s | @vueuse/head',
   })
 
   app.use(head)

--- a/examples/vite-ssr/main.tsx
+++ b/examples/vite-ssr/main.tsx
@@ -1,10 +1,10 @@
-import { createApp } from "./app"
+import { createApp } from './app'
 
 const { app, router, head } = createApp()
 
 router.isReady().then(() => {
-  app.mount("#app")
+  app.mount('#app')
 
-  // @ts-expect-error
+  // @ts-expect-error untyped
   window.head = head
 })

--- a/examples/vite-ssr/pages/ssr/dedup.vue
+++ b/examples/vite-ssr/pages/ssr/dedup.vue
@@ -1,11 +1,11 @@
 <script setup>
-import { useHead } from "../../../../src"
+import { useHead } from '../../../../src'
 
 useHead({
   style: [
     {
-      type: "text/css",
-      id: "darkStyle",
+      type: 'text/css',
+      id: 'darkStyle',
       children: `
         body {
           background-color: #000;
@@ -49,5 +49,5 @@ useHead({
 </script>
 
 <template>
-  <table id="logs"></table>
+  <table id="logs" />
 </template>

--- a/examples/vite-ssr/vite.config.ts
+++ b/examples/vite-ssr/vite.config.ts
@@ -1,9 +1,10 @@
-import fs from "fs"
-import { defineConfig } from "vite"
-import vueJsx from "@vitejs/plugin-vue-jsx"
-import vue from "@vitejs/plugin-vue"
-import { renderToString } from "@vue/server-renderer"
-import { renderHeadToString } from "../../src"
+import fs from 'fs'
+import { resolve } from 'node:path'
+import { defineConfig } from 'vite'
+import vueJsx from '@vitejs/plugin-vue-jsx'
+import vue from '@vitejs/plugin-vue'
+import { renderToString } from '@vue/server-renderer'
+import { renderHeadToString } from '../../src'
 
 export default defineConfig({
   plugins: [
@@ -12,30 +13,29 @@ export default defineConfig({
     }),
     vue({}),
     {
-      name: "ssr",
+      name: 'ssr',
       configureServer(server) {
         server.middlewares.use(async (req, res, next) => {
-          if (!req.url!.startsWith("/ssr/")) {
+          if (!req.url!.startsWith('/ssr/'))
             return next()
-          }
 
-          let html = fs.readFileSync(__dirname + "/index.html", "utf8")
+          let html = fs.readFileSync(resolve(__dirname, 'index.html'), 'utf8')
 
           const mod = (await server.ssrLoadModule(
-            `/app.tsx`,
-          )) as typeof import("./app")
+            '/app.tsx',
+          )) as typeof import('./app')
           const { app, router, head } = mod.createApp()
           await router.push(req.url!)
           await router.isReady()
           const appHTML = await renderToString(app)
           const headHTML = renderHeadToString(head)
           html = await server.transformIndexHtml(req.url!, html)
-          res.setHeader("content-type", "text/html")
+          res.setHeader('content-type', 'text/html')
           res.end(
             html
-              .replace("<html>", `<html${headHTML.htmlAttrs}>`)
-              .replace("<body>", `<body${headHTML.bodyAttrs}>`)
-              .replace("</head>", `${headHTML.headTags}</head>`)
+              .replace('<html>', `<html${headHTML.htmlAttrs}>`)
+              .replace('<body>', `<body${headHTML.bodyAttrs}>`)
+              .replace('</head>', `${headHTML.headTags}</head>`)
               .replace(
                 '<div id="app"></div>',
                 `<div id="app">${appHTML}</div>`,

--- a/package.json
+++ b/package.json
@@ -1,9 +1,17 @@
 {
   "name": "@vueuse/head",
-  "packageManager": "pnpm@7.5.0",
   "version": "0.7.13",
-  "license": "MIT",
+  "packageManager": "pnpm@7.5.0",
   "description": "Document head manager for Vue 3. SSR ready.",
+  "author": {
+    "name": "EGOIST",
+    "url": "https://egoist.sh"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vueuse/head"
+  },
   "keywords": [
     "vue",
     "head",
@@ -14,6 +22,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "sideEffects": false,
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
@@ -26,27 +35,17 @@
     "prepublishOnly": "npm run build",
     "test": "nuxi prepare examples/nuxt3 && vitest",
     "test:e2e": "vitest tests/e2e",
-    "release": "kanpai"
+    "release": "kanpai",
+    "lint": "eslint \"**/*.{ts,vue,json,yml,tsx}\" --fix"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/vueuse/head"
+  "peerDependencies": {
+    "vue": ">=2.7 || >=3"
   },
-  "author": {
-    "name": "EGOIST",
-    "url": "https://egoist.sh"
+  "dependencies": {
+    "@zhead/schema-vue": "^0.7.3"
   },
-  "simple-git-hooks": {
-    "pre-commit": "npx lint-staged"
-  },
-  "lint-staged": {
-    "*.{ts,tsx}": [
-      "prettier --write"
-    ]
-  },
-  "sideEffects": false,
   "devDependencies": {
-    "@egoist/prettier-config": "^1.0.0",
+    "@antfu/eslint-config": "^0.27.0",
     "@nuxt/kit": "3.0.0-rc.11",
     "@nuxt/test-utils": "3.0.0-rc.11",
     "@vitejs/plugin-vue": "^3.1.0",
@@ -54,6 +53,7 @@
     "@vue/compiler-sfc": "^3.2.39",
     "@vue/server-renderer": "^3.2.39",
     "cheerio": "1.0.0-rc.12",
+    "eslint": "^8.24.0",
     "execa": "^6.1.0",
     "get-port-please": "^2.6.1",
     "jsdom": "^20.0.0",
@@ -63,7 +63,6 @@
     "nuxt": "3.0.0-rc.11",
     "pathe": "^0.3.7",
     "playwright": "^1.25.2",
-    "prettier": "^2.7.1",
     "simple-git-hooks": "^2.8.0",
     "tsup": "^6.2.3",
     "typescript": "^4.8.3",
@@ -72,13 +71,15 @@
     "vue": "^3.2.39",
     "vue-router": "^4.1.5"
   },
-  "peerDependencies": {
-    "vue": ">=2.7 || >=3"
-  },
-  "dependencies": {
-    "@zhead/schema-vue": "^0.7.3"
-  },
   "resolutions": {
     "@vueuse/head": "link:."
+  },
+  "simple-git-hooks": {
+    "pre-commit": "npx lint-staged"
+  },
+  "lint-staged": {
+    "*.{ts,vue,json,yml,tsx}": [
+      "eslint \"**/*.{ts,vue,json,yml,tsx}\" --fix"
+    ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,7 @@ overrides:
   '@vueuse/head': link:.
 
 specifiers:
-  '@egoist/prettier-config': ^1.0.0
+  '@antfu/eslint-config': ^0.27.0
   '@nuxt/kit': 3.0.0-rc.11
   '@nuxt/test-utils': 3.0.0-rc.11
   '@vitejs/plugin-vue': ^3.1.0
@@ -13,6 +13,7 @@ specifiers:
   '@vue/server-renderer': ^3.2.39
   '@zhead/schema-vue': ^0.7.3
   cheerio: 1.0.0-rc.12
+  eslint: ^8.24.0
   execa: ^6.1.0
   get-port-please: ^2.6.1
   jsdom: ^20.0.0
@@ -22,7 +23,6 @@ specifiers:
   nuxt: 3.0.0-rc.11
   pathe: ^0.3.7
   playwright: ^1.25.2
-  prettier: ^2.7.1
   simple-git-hooks: ^2.8.0
   tsup: ^6.2.3
   typescript: ^4.8.3
@@ -35,7 +35,7 @@ dependencies:
   '@zhead/schema-vue': 0.7.3_vue@3.2.39
 
 devDependencies:
-  '@egoist/prettier-config': 1.0.0
+  '@antfu/eslint-config': 0.27.0_7ilbxdl5iguzcjriqqcg2m5cku
   '@nuxt/kit': 3.0.0-rc.11_vite@3.1.2
   '@nuxt/test-utils': 3.0.0-rc.11_vite@3.1.2+vue@3.2.39
   '@vitejs/plugin-vue': 3.1.0_vite@3.1.2+vue@3.2.39
@@ -43,16 +43,16 @@ devDependencies:
   '@vue/compiler-sfc': 3.2.39
   '@vue/server-renderer': 3.2.39_vue@3.2.39
   cheerio: 1.0.0-rc.12
+  eslint: 8.24.0
   execa: 6.1.0
   get-port-please: 2.6.1
   jsdom: 20.0.0
   kanpai: 0.11.0
   lint-staged: 13.0.3
   mlly: 0.5.14
-  nuxt: 3.0.0-rc.11_rotfulo2ionxm6wnqfjte3okw4
+  nuxt: 3.0.0-rc.11_rigehccanlnv2oyjejvvvoyy2u
   pathe: 0.3.7
   playwright: 1.25.2
-  prettier: 2.7.1
   simple-git-hooks: 2.8.0
   tsup: 6.2.3_typescript@4.8.3
   typescript: 4.8.3
@@ -69,6 +69,91 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.1.1
       '@jridgewell/trace-mapping': 0.3.15
+    dev: true
+
+  /@antfu/eslint-config-basic/0.27.0_qatzzi2vqzjqg2tq57nszrvcfi:
+    resolution: {integrity: sha512-QgQVCiNiV9ZF7h09uBqTHctHDfVqJGIIpe0ZHCicLvUv233nAYeu4adAr53buhKrxDeoalozSs2ePiDiCyceTg==}
+    peerDependencies:
+      eslint: '>=7.4.0'
+    dependencies:
+      eslint: 8.24.0
+      eslint-plugin-antfu: 0.27.0_7ilbxdl5iguzcjriqqcg2m5cku
+      eslint-plugin-eslint-comments: 3.2.0_eslint@8.24.0
+      eslint-plugin-html: 7.1.0
+      eslint-plugin-import: 2.26.0_gofx6msuqd4luqedfouzks2s4u
+      eslint-plugin-jsonc: 2.4.0_eslint@8.24.0
+      eslint-plugin-markdown: 3.0.0_eslint@8.24.0
+      eslint-plugin-n: 15.3.0_eslint@8.24.0
+      eslint-plugin-promise: 6.0.1_eslint@8.24.0
+      eslint-plugin-unicorn: 43.0.2_eslint@8.24.0
+      eslint-plugin-yml: 1.2.0_eslint@8.24.0
+      jsonc-eslint-parser: 2.1.0
+      yaml-eslint-parser: 1.1.0
+    transitivePeerDependencies:
+      - '@typescript-eslint/parser'
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+      - typescript
+    dev: true
+
+  /@antfu/eslint-config-ts/0.27.0_7ilbxdl5iguzcjriqqcg2m5cku:
+    resolution: {integrity: sha512-h/ai9xe65lXtsUiSBRAvfcN47fqn5uGHcCA5c0LoBRX6fVFHk06BbPWMlSJRtqmc3uBTmv3gU8SrnWwrycnKag==}
+    peerDependencies:
+      eslint: '>=7.4.0'
+      typescript: '>=3.9'
+    dependencies:
+      '@antfu/eslint-config-basic': 0.27.0_qatzzi2vqzjqg2tq57nszrvcfi
+      '@typescript-eslint/eslint-plugin': 5.38.1_qatzzi2vqzjqg2tq57nszrvcfi
+      '@typescript-eslint/parser': 5.38.1_7ilbxdl5iguzcjriqqcg2m5cku
+      eslint: 8.24.0
+      typescript: 4.8.3
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+    dev: true
+
+  /@antfu/eslint-config-vue/0.27.0_7ilbxdl5iguzcjriqqcg2m5cku:
+    resolution: {integrity: sha512-Iw4GY4rXK1dPxzIl35bOwPE1vn6E5Wm8uljqdpQYQpTX1j6el7Yo30bpanCogWRcdPSMWKcS7GVlHjV47QB59w==}
+    peerDependencies:
+      eslint: '>=7.4.0'
+    dependencies:
+      '@antfu/eslint-config-ts': 0.27.0_7ilbxdl5iguzcjriqqcg2m5cku
+      eslint: 8.24.0
+      eslint-plugin-vue: 9.5.1_eslint@8.24.0
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+      - typescript
+    dev: true
+
+  /@antfu/eslint-config/0.27.0_7ilbxdl5iguzcjriqqcg2m5cku:
+    resolution: {integrity: sha512-xM1In6/ueNyKxxWO86jd7a9IdKby66lZVT/fE8k2RlP+X0xe5/DTTQfwLbVvnRpn77jCPIhEjNKVWxDO/DUEIg==}
+    peerDependencies:
+      eslint: '>=7.4.0'
+    dependencies:
+      '@antfu/eslint-config-vue': 0.27.0_7ilbxdl5iguzcjriqqcg2m5cku
+      '@typescript-eslint/eslint-plugin': 5.38.1_qatzzi2vqzjqg2tq57nszrvcfi
+      '@typescript-eslint/parser': 5.38.1_7ilbxdl5iguzcjriqqcg2m5cku
+      eslint: 8.24.0
+      eslint-plugin-eslint-comments: 3.2.0_eslint@8.24.0
+      eslint-plugin-html: 7.1.0
+      eslint-plugin-import: 2.26.0_gofx6msuqd4luqedfouzks2s4u
+      eslint-plugin-jsonc: 2.4.0_eslint@8.24.0
+      eslint-plugin-n: 15.3.0_eslint@8.24.0
+      eslint-plugin-promise: 6.0.1_eslint@8.24.0
+      eslint-plugin-unicorn: 43.0.2_eslint@8.24.0
+      eslint-plugin-vue: 9.5.1_eslint@8.24.0
+      eslint-plugin-yml: 1.2.0_eslint@8.24.0
+      jsonc-eslint-parser: 2.1.0
+      yaml-eslint-parser: 1.1.0
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+      - typescript
     dev: true
 
   /@babel/code-frame/7.18.6:
@@ -376,10 +461,6 @@ packages:
       mime: 3.0.0
     dev: true
 
-  /@egoist/prettier-config/1.0.0:
-    resolution: {integrity: sha512-D1Tp9Jv4aVoEo3cOAO966gFCI0wx/1lZ6sEHX8uMAfyVxuxD2+knGxhfGlb/FNLxWV3ifSI5hOmB/zFfsi7Rzw==}
-    dev: true
-
   /@esbuild/android-arm/0.15.10:
     resolution: {integrity: sha512-FNONeQPy/ox+5NBkcSbYJxoXj9GWu8gVGJTVmUyoOCKQFDTrHVKgNSzChdNt0I8Aj/iKcsDf2r9BFwv+FSNUXg==}
     engines: {node: '>=12'}
@@ -406,6 +487,47 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
+
+  /@eslint/eslintrc/1.3.2:
+    resolution: {integrity: sha512-AXYd23w1S/bv3fTs3Lz0vjiYemS08jWkI3hYyS9I1ry+0f+Yjs1wm+sU0BS8qDOPrBIkp4qHYC16I8uVtpLajQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.3.4
+      espree: 9.4.0
+      globals: 13.17.0
+      ignore: 5.2.0
+      import-fresh: 3.3.0
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@humanwhocodes/config-array/0.10.7:
+    resolution: {integrity: sha512-MDl6D6sBsaV452/QSdX+4CXIjZhIcI0PELsxUjk4U828yd58vk3bTIvk/6w5FY+4hIy9sLW0sfrV7K7Kc++j/w==}
+    engines: {node: '>=10.10.0'}
+    dependencies:
+      '@humanwhocodes/object-schema': 1.2.1
+      debug: 4.3.4
+      minimatch: 3.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@humanwhocodes/gitignore-to-minimatch/1.0.2:
+    resolution: {integrity: sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==}
+    dev: true
+
+  /@humanwhocodes/module-importer/1.0.1:
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+    dev: true
+
+  /@humanwhocodes/object-schema/1.2.1:
+    resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
+    dev: true
 
   /@ioredis/commands/1.2.0:
     resolution: {integrity: sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==}
@@ -685,7 +807,7 @@ packages:
     resolution: {integrity: sha512-oFjUfn9r9U4vNljd5uU08+6M3mF6OSxZfCrfqJQaN5TtqVTcZmZFzOZ4H866Lq+Eaugv/Vte225kuaZCB3FR/g==}
     dev: true
 
-  /@nuxt/vite-builder/3.0.0-rc.11_arz4dztosvwy2ghjrlh2wdhejm:
+  /@nuxt/vite-builder/3.0.0-rc.11_ywj4bzdq3gzot7ep3achw2p3wa:
     resolution: {integrity: sha512-WkQ+/cfdIf5XVZea8xD+ciLXpmQkNu8d5p16WJSp10hEhj3Vt/cQ8OkXDVHGGRML+NsDL0bQXDeg3PcM/bw94w==}
     engines: {node: ^14.16.0 || ^16.11.0 || ^17.0.0 || ^18.0.0}
     peerDependencies:
@@ -722,7 +844,7 @@ packages:
       unplugin: 0.9.5_vjldd2ewyhqwpukg6innqzjpqe
       vite: 3.1.4
       vite-node: 0.23.4
-      vite-plugin-checker: 0.5.1_nijwsw6kalmosfobgutypnhyhi
+      vite-plugin-checker: 0.5.1_dtveubzuwdz4s34cbjaxelqvm4
       vue: 3.2.39
       vue-bundle-renderer: 0.4.3
     transitivePeerDependencies:
@@ -866,14 +988,162 @@ packages:
     resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}
     dev: true
 
+  /@types/json-schema/7.0.11:
+    resolution: {integrity: sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==}
+    dev: true
+
+  /@types/json5/0.0.29:
+    resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+    dev: true
+
+  /@types/mdast/3.0.10:
+    resolution: {integrity: sha512-W864tg/Osz1+9f4lrGTZpCSO5/z4608eUp19tbozkq2HJK6i3z1kT0H9tlADXuYIb1YYOBByU4Jsqkk75q48qA==}
+    dependencies:
+      '@types/unist': 2.0.6
+    dev: true
+
   /@types/node/16.11.7:
     resolution: {integrity: sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw==}
+    dev: true
+
+  /@types/normalize-package-data/2.4.1:
+    resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
     dev: true
 
   /@types/resolve/1.17.1:
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
     dependencies:
       '@types/node': 16.11.7
+    dev: true
+
+  /@types/unist/2.0.6:
+    resolution: {integrity: sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==}
+    dev: true
+
+  /@typescript-eslint/eslint-plugin/5.38.1_qatzzi2vqzjqg2tq57nszrvcfi:
+    resolution: {integrity: sha512-ky7EFzPhqz3XlhS7vPOoMDaQnQMn+9o5ICR9CPr/6bw8HrFkzhMSxuA3gRfiJVvs7geYrSeawGJjZoZQKCOglQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^5.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 5.38.1_7ilbxdl5iguzcjriqqcg2m5cku
+      '@typescript-eslint/scope-manager': 5.38.1
+      '@typescript-eslint/type-utils': 5.38.1_7ilbxdl5iguzcjriqqcg2m5cku
+      '@typescript-eslint/utils': 5.38.1_7ilbxdl5iguzcjriqqcg2m5cku
+      debug: 4.3.4
+      eslint: 8.24.0
+      ignore: 5.2.0
+      regexpp: 3.2.0
+      semver: 7.3.7
+      tsutils: 3.21.0_typescript@4.8.3
+      typescript: 4.8.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/parser/5.38.1_7ilbxdl5iguzcjriqqcg2m5cku:
+    resolution: {integrity: sha512-LDqxZBVFFQnQRz9rUZJhLmox+Ep5kdUmLatLQnCRR6523YV+XhRjfYzStQ4MheFA8kMAfUlclHSbu+RKdRwQKw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 5.38.1
+      '@typescript-eslint/types': 5.38.1
+      '@typescript-eslint/typescript-estree': 5.38.1_typescript@4.8.3
+      debug: 4.3.4
+      eslint: 8.24.0
+      typescript: 4.8.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/scope-manager/5.38.1:
+    resolution: {integrity: sha512-BfRDq5RidVU3RbqApKmS7RFMtkyWMM50qWnDAkKgQiezRtLKsoyRKIvz1Ok5ilRWeD9IuHvaidaLxvGx/2eqTQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.38.1
+      '@typescript-eslint/visitor-keys': 5.38.1
+    dev: true
+
+  /@typescript-eslint/type-utils/5.38.1_7ilbxdl5iguzcjriqqcg2m5cku:
+    resolution: {integrity: sha512-UU3j43TM66gYtzo15ivK2ZFoDFKKP0k03MItzLdq0zV92CeGCXRfXlfQX5ILdd4/DSpHkSjIgLLLh1NtkOJOAw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/typescript-estree': 5.38.1_typescript@4.8.3
+      '@typescript-eslint/utils': 5.38.1_7ilbxdl5iguzcjriqqcg2m5cku
+      debug: 4.3.4
+      eslint: 8.24.0
+      tsutils: 3.21.0_typescript@4.8.3
+      typescript: 4.8.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/types/5.38.1:
+    resolution: {integrity: sha512-QTW1iHq1Tffp9lNfbfPm4WJabbvpyaehQ0SrvVK2yfV79SytD9XDVxqiPvdrv2LK7DGSFo91TB2FgWanbJAZXg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
+  /@typescript-eslint/typescript-estree/5.38.1_typescript@4.8.3:
+    resolution: {integrity: sha512-99b5e/Enoe8fKMLdSuwrfH/C0EIbpUWmeEKHmQlGZb8msY33qn1KlkFww0z26o5Omx7EVjzVDCWEfrfCDHfE7g==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 5.38.1
+      '@typescript-eslint/visitor-keys': 5.38.1
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.3.7
+      tsutils: 3.21.0_typescript@4.8.3
+      typescript: 4.8.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/utils/5.38.1_7ilbxdl5iguzcjriqqcg2m5cku:
+    resolution: {integrity: sha512-oIuUiVxPBsndrN81oP8tXnFa/+EcZ03qLqPDfSZ5xIJVm7A9V0rlkQwwBOAGtrdN70ZKDlKv+l1BeT4eSFxwXA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@types/json-schema': 7.0.11
+      '@typescript-eslint/scope-manager': 5.38.1
+      '@typescript-eslint/types': 5.38.1
+      '@typescript-eslint/typescript-estree': 5.38.1_typescript@4.8.3
+      eslint: 8.24.0
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0_eslint@8.24.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /@typescript-eslint/visitor-keys/5.38.1:
+    resolution: {integrity: sha512-bSHr1rRxXt54+j2n4k54p4fj8AHJ49VDWtjpImOpzQj4qjAiOpPni+V1Tyajh19Api1i844F757cur8wH3YvOA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.38.1
+      eslint-visitor-keys: 3.3.0
     dev: true
 
   /@vercel/nft/0.22.1:
@@ -1090,6 +1360,14 @@ packages:
       acorn-walk: 7.2.0
     dev: true
 
+  /acorn-jsx/5.3.2_acorn@8.8.0:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      acorn: 8.8.0
+    dev: true
+
   /acorn-walk/7.2.0:
     resolution: {integrity: sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==}
     engines: {node: '>=0.4.0'}
@@ -1122,6 +1400,15 @@ packages:
     dependencies:
       clean-stack: 2.2.0
       indent-string: 4.0.0
+    dev: true
+
+  /ajv/6.12.6:
+    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
     dev: true
 
   /ansi-escapes/4.3.2:
@@ -1224,9 +1511,34 @@ packages:
       readable-stream: 3.6.0
     dev: true
 
+  /argparse/2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+    dev: true
+
+  /array-includes/3.1.5:
+    resolution: {integrity: sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.1.4
+      es-abstract: 1.20.3
+      get-intrinsic: 1.1.3
+      is-string: 1.0.7
+    dev: true
+
   /array-union/2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
+    dev: true
+
+  /array.prototype.flat/1.3.0:
+    resolution: {integrity: sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.1.4
+      es-abstract: 1.20.3
+      es-shim-unscopables: 1.0.0
     dev: true
 
   /assertion-error/1.1.0:
@@ -1367,6 +1679,12 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /builtins/5.0.1:
+    resolution: {integrity: sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==}
+    dependencies:
+      semver: 7.3.7
+    dev: true
+
   /bundle-require/3.1.0_esbuild@0.15.7:
     resolution: {integrity: sha512-IIXtAO7fKcwPHNPt9kY/WNVJqy7NDy6YqJvv6ENH0TOZoJ+yjpEsn1w40WKZbR2ibfu5g1rfgJTvmFHpm5aOMA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -1393,6 +1711,18 @@ packages:
   /cac/6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+    dev: true
+
+  /call-bind/1.0.2:
+    resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
+    dependencies:
+      function-bind: 1.1.1
+      get-intrinsic: 1.1.3
+    dev: true
+
+  /callsites/3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
     dev: true
 
   /camelcase/6.3.0:
@@ -1446,6 +1776,18 @@ packages:
   /chalk/5.0.1:
     resolution: {integrity: sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+    dev: true
+
+  /character-entities-legacy/1.1.4:
+    resolution: {integrity: sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==}
+    dev: true
+
+  /character-entities/1.2.4:
+    resolution: {integrity: sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==}
+    dev: true
+
+  /character-reference-invalid/1.1.4:
+    resolution: {integrity: sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==}
     dev: true
 
   /chardet/0.7.0:
@@ -1506,6 +1848,13 @@ packages:
 
   /ci-info/3.4.0:
     resolution: {integrity: sha512-t5QdPT5jq3o262DOQ8zA6E1tlH2upmUc4Hlvrbx1pGYJuiiHl7O7rvVNI+l8HTVhd/q3Qc9vqimkNk5yiXsAug==}
+    dev: true
+
+  /clean-regexp/1.0.0:
+    resolution: {integrity: sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==}
+    engines: {node: '>=4'}
+    dependencies:
+      escape-string-regexp: 1.0.5
     dev: true
 
   /clean-stack/2.2.0:
@@ -1640,8 +1989,8 @@ packages:
     engines: {node: '>= 12'}
     dev: true
 
-  /commander/9.4.0:
-    resolution: {integrity: sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==}
+  /commander/9.4.1:
+    resolution: {integrity: sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==}
     engines: {node: ^12.20.0 || >=14}
     dev: true
 
@@ -1873,6 +2222,17 @@ packages:
       ms: 2.0.0
     dev: true
 
+  /debug/3.2.7:
+    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.3
+    dev: true
+
   /debug/4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
@@ -1914,6 +2274,14 @@ packages:
   /define-lazy-prop/2.0.0:
     resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
     engines: {node: '>=8'}
+    dev: true
+
+  /define-properties/1.1.4:
+    resolution: {integrity: sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      has-property-descriptors: 1.0.0
+      object-keys: 1.1.1
     dev: true
 
   /defu/6.1.0:
@@ -1958,6 +2326,20 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       path-type: 4.0.0
+    dev: true
+
+  /doctrine/2.1.0:
+    resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      esutils: 2.0.3
+    dev: true
+
+  /doctrine/3.0.0:
+    resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      esutils: 2.0.3
     dev: true
 
   /dom-serializer/1.4.1:
@@ -2095,6 +2477,57 @@ packages:
     hasBin: true
     dependencies:
       prr: 1.0.1
+    dev: true
+
+  /error-ex/1.3.2:
+    resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
+    dependencies:
+      is-arrayish: 0.2.1
+    dev: true
+
+  /es-abstract/1.20.3:
+    resolution: {integrity: sha512-AyrnaKVpMzljIdwjzrj+LxGmj8ik2LckwXacHqrJJ/jxz6dDDBcZ7I7nlHM0FvEW8MfbWJwOd+yT2XzYW49Frw==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      es-to-primitive: 1.2.1
+      function-bind: 1.1.1
+      function.prototype.name: 1.1.5
+      get-intrinsic: 1.1.3
+      get-symbol-description: 1.0.0
+      has: 1.0.3
+      has-property-descriptors: 1.0.0
+      has-symbols: 1.0.3
+      internal-slot: 1.0.3
+      is-callable: 1.2.7
+      is-negative-zero: 2.0.2
+      is-regex: 1.1.4
+      is-shared-array-buffer: 1.0.2
+      is-string: 1.0.7
+      is-weakref: 1.0.2
+      object-inspect: 1.12.2
+      object-keys: 1.1.1
+      object.assign: 4.1.4
+      regexp.prototype.flags: 1.4.3
+      safe-regex-test: 1.0.0
+      string.prototype.trimend: 1.0.5
+      string.prototype.trimstart: 1.0.5
+      unbox-primitive: 1.0.2
+    dev: true
+
+  /es-shim-unscopables/1.0.0:
+    resolution: {integrity: sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==}
+    dependencies:
+      has: 1.0.3
+    dev: true
+
+  /es-to-primitive/1.2.1:
+    resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      is-callable: 1.2.7
+      is-date-object: 1.0.5
+      is-symbol: 1.0.4
     dev: true
 
   /esbuild-android-64/0.15.10:
@@ -2530,6 +2963,11 @@ packages:
     engines: {node: '>=0.8.0'}
     dev: true
 
+  /escape-string-regexp/4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+    dev: true
+
   /escape-string-regexp/5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
@@ -2548,10 +2986,347 @@ packages:
       source-map: 0.6.1
     dev: true
 
+  /eslint-import-resolver-node/0.3.6:
+    resolution: {integrity: sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==}
+    dependencies:
+      debug: 3.2.7
+      resolve: 1.22.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /eslint-module-utils/2.7.4_k7674c2ukyqtflgonkjv2n7c7y:
+    resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 5.38.1_7ilbxdl5iguzcjriqqcg2m5cku
+      debug: 3.2.7
+      eslint: 8.24.0
+      eslint-import-resolver-node: 0.3.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /eslint-plugin-antfu/0.27.0_7ilbxdl5iguzcjriqqcg2m5cku:
+    resolution: {integrity: sha512-xjNfATHonE3Do2igOlhwjfL2tlaGnm1EgbsLLkHgdk30oIvJU4bLNxF6wXIuaCdjqmwWIqF6smJbX2YhtaEC4w==}
+    dependencies:
+      '@typescript-eslint/utils': 5.38.1_7ilbxdl5iguzcjriqqcg2m5cku
+    transitivePeerDependencies:
+      - eslint
+      - supports-color
+      - typescript
+    dev: true
+
+  /eslint-plugin-es/4.1.0_eslint@8.24.0:
+    resolution: {integrity: sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==}
+    engines: {node: '>=8.10.0'}
+    peerDependencies:
+      eslint: '>=4.19.1'
+    dependencies:
+      eslint: 8.24.0
+      eslint-utils: 2.1.0
+      regexpp: 3.2.0
+    dev: true
+
+  /eslint-plugin-eslint-comments/3.2.0_eslint@8.24.0:
+    resolution: {integrity: sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==}
+    engines: {node: '>=6.5.0'}
+    peerDependencies:
+      eslint: '>=4.19.1'
+    dependencies:
+      escape-string-regexp: 1.0.5
+      eslint: 8.24.0
+      ignore: 5.2.0
+    dev: true
+
+  /eslint-plugin-html/7.1.0:
+    resolution: {integrity: sha512-fNLRraV/e6j8e3XYOC9xgND4j+U7b1Rq+OygMlLcMg+wI/IpVbF+ubQa3R78EjKB9njT6TQOlcK5rFKBVVtdfg==}
+    dependencies:
+      htmlparser2: 8.0.1
+    dev: true
+
+  /eslint-plugin-import/2.26.0_gofx6msuqd4luqedfouzks2s4u:
+    resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 5.38.1_7ilbxdl5iguzcjriqqcg2m5cku
+      array-includes: 3.1.5
+      array.prototype.flat: 1.3.0
+      debug: 2.6.9
+      doctrine: 2.1.0
+      eslint: 8.24.0
+      eslint-import-resolver-node: 0.3.6
+      eslint-module-utils: 2.7.4_k7674c2ukyqtflgonkjv2n7c7y
+      has: 1.0.3
+      is-core-module: 2.10.0
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.values: 1.1.5
+      resolve: 1.22.1
+      tsconfig-paths: 3.14.1
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+    dev: true
+
+  /eslint-plugin-jsonc/2.4.0_eslint@8.24.0:
+    resolution: {integrity: sha512-YXy5PjyUL9gFYal6pYijd8P6EmpeWskv7PVhB9Py/AwKPn+hwnQHcIzQILiLfxztfhtWiRIUSzoLe/JThZgSUw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '>=6.0.0'
+    dependencies:
+      eslint: 8.24.0
+      eslint-utils: 3.0.0_eslint@8.24.0
+      jsonc-eslint-parser: 2.1.0
+      natural-compare: 1.4.0
+    dev: true
+
+  /eslint-plugin-markdown/3.0.0_eslint@8.24.0:
+    resolution: {integrity: sha512-hRs5RUJGbeHDLfS7ELanT0e29Ocyssf/7kBM+p7KluY5AwngGkDf8Oyu4658/NZSGTTq05FZeWbkxXtbVyHPwg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      eslint: 8.24.0
+      mdast-util-from-markdown: 0.8.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /eslint-plugin-n/15.3.0_eslint@8.24.0:
+    resolution: {integrity: sha512-IyzPnEWHypCWasDpxeJnim60jhlumbmq0pubL6IOcnk8u2y53s5QfT8JnXy7skjHJ44yWHRb11PLtDHuu1kg/Q==}
+    engines: {node: '>=12.22.0'}
+    peerDependencies:
+      eslint: '>=7.0.0'
+    dependencies:
+      builtins: 5.0.1
+      eslint: 8.24.0
+      eslint-plugin-es: 4.1.0_eslint@8.24.0
+      eslint-utils: 3.0.0_eslint@8.24.0
+      ignore: 5.2.0
+      is-core-module: 2.10.0
+      minimatch: 3.1.2
+      resolve: 1.22.1
+      semver: 7.3.7
+    dev: true
+
+  /eslint-plugin-promise/6.0.1_eslint@8.24.0:
+    resolution: {integrity: sha512-uM4Tgo5u3UWQiroOyDEsYcVMOo7re3zmno0IZmB5auxoaQNIceAbXEkSt8RNrKtaYehARHG06pYK6K1JhtP0Zw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+    dependencies:
+      eslint: 8.24.0
+    dev: true
+
+  /eslint-plugin-unicorn/43.0.2_eslint@8.24.0:
+    resolution: {integrity: sha512-DtqZ5mf/GMlfWoz1abIjq5jZfaFuHzGBZYIeuJfEoKKGWRHr2JiJR+ea+BF7Wx2N1PPRoT/2fwgiK1NnmNE3Hg==}
+    engines: {node: '>=14.18'}
+    peerDependencies:
+      eslint: '>=8.18.0'
+    dependencies:
+      '@babel/helper-validator-identifier': 7.19.1
+      ci-info: 3.4.0
+      clean-regexp: 1.0.0
+      eslint: 8.24.0
+      eslint-utils: 3.0.0_eslint@8.24.0
+      esquery: 1.4.0
+      indent-string: 4.0.0
+      is-builtin-module: 3.2.0
+      lodash: 4.17.21
+      pluralize: 8.0.0
+      read-pkg-up: 7.0.1
+      regexp-tree: 0.1.24
+      safe-regex: 2.1.1
+      semver: 7.3.7
+      strip-indent: 3.0.0
+    dev: true
+
+  /eslint-plugin-vue/9.5.1_eslint@8.24.0:
+    resolution: {integrity: sha512-Y0sL2RY7Xc9S8kNih9lbwHIDmewUg9bfas6WSzsOWRgDXhIHKxRBZYNAnVcXBFfE+bMWHUA5GLChl7TcTYUI8w==}
+    engines: {node: ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.2.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      eslint: 8.24.0
+      eslint-utils: 3.0.0_eslint@8.24.0
+      natural-compare: 1.4.0
+      nth-check: 2.1.1
+      postcss-selector-parser: 6.0.10
+      semver: 7.3.7
+      vue-eslint-parser: 9.1.0_eslint@8.24.0
+      xml-name-validator: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /eslint-plugin-yml/1.2.0_eslint@8.24.0:
+    resolution: {integrity: sha512-v0jAU/F5SJg28zkpxwGpY04eGZMWFP6os8u2qaEAIRjSH2GqrNl0yBR5+sMHLU/026kAduxVbvLSqmT3Mu3O0g==}
+    engines: {node: ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '>=6.0.0'
+    dependencies:
+      debug: 4.3.4
+      eslint: 8.24.0
+      lodash: 4.17.21
+      natural-compare: 1.4.0
+      yaml-eslint-parser: 1.1.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /eslint-scope/5.1.1:
+    resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
+    engines: {node: '>=8.0.0'}
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 4.3.0
+    dev: true
+
+  /eslint-scope/7.1.1:
+    resolution: {integrity: sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+    dev: true
+
+  /eslint-utils/2.1.0:
+    resolution: {integrity: sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==}
+    engines: {node: '>=6'}
+    dependencies:
+      eslint-visitor-keys: 1.3.0
+    dev: true
+
+  /eslint-utils/3.0.0_eslint@8.24.0:
+    resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
+    engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
+    peerDependencies:
+      eslint: '>=5'
+    dependencies:
+      eslint: 8.24.0
+      eslint-visitor-keys: 2.1.0
+    dev: true
+
+  /eslint-visitor-keys/1.3.0:
+    resolution: {integrity: sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==}
+    engines: {node: '>=4'}
+    dev: true
+
+  /eslint-visitor-keys/2.1.0:
+    resolution: {integrity: sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==}
+    engines: {node: '>=10'}
+    dev: true
+
+  /eslint-visitor-keys/3.3.0:
+    resolution: {integrity: sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
+  /eslint/8.24.0:
+    resolution: {integrity: sha512-dWFaPhGhTAiPcCgm3f6LI2MBWbogMnTJzFBbhXVRQDJPkr9pGZvVjlVfXd+vyDcWPA2Ic9L2AXPIQM0+vk/cSQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    hasBin: true
+    dependencies:
+      '@eslint/eslintrc': 1.3.2
+      '@humanwhocodes/config-array': 0.10.7
+      '@humanwhocodes/gitignore-to-minimatch': 1.0.2
+      '@humanwhocodes/module-importer': 1.0.1
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.3
+      debug: 4.3.4
+      doctrine: 3.0.0
+      escape-string-regexp: 4.0.0
+      eslint-scope: 7.1.1
+      eslint-utils: 3.0.0_eslint@8.24.0
+      eslint-visitor-keys: 3.3.0
+      espree: 9.4.0
+      esquery: 1.4.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 6.0.1
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      globals: 13.17.0
+      globby: 11.1.0
+      grapheme-splitter: 1.0.4
+      ignore: 5.2.0
+      import-fresh: 3.3.0
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      js-sdsl: 4.1.4
+      js-yaml: 4.1.0
+      json-stable-stringify-without-jsonify: 1.0.1
+      levn: 0.4.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.1
+      regexpp: 3.2.0
+      strip-ansi: 6.0.1
+      strip-json-comments: 3.1.1
+      text-table: 0.2.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /espree/9.4.0:
+    resolution: {integrity: sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      acorn: 8.8.0
+      acorn-jsx: 5.3.2_acorn@8.8.0
+      eslint-visitor-keys: 3.3.0
+    dev: true
+
   /esprima/4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
+    dev: true
+
+  /esquery/1.4.0:
+    resolution: {integrity: sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==}
+    engines: {node: '>=0.10'}
+    dependencies:
+      estraverse: 5.3.0
+    dev: true
+
+  /esrecurse/4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+    dependencies:
+      estraverse: 5.3.0
+    dev: true
+
+  /estraverse/4.3.0:
+    resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==}
+    engines: {node: '>=4.0'}
     dev: true
 
   /estraverse/5.3.0:
@@ -2636,6 +3411,10 @@ packages:
       ufo: 0.8.5
     dev: true
 
+  /fast-deep-equal/3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+    dev: true
+
   /fast-glob/3.2.12:
     resolution: {integrity: sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==}
     engines: {node: '>=8.6.0'}
@@ -2645,6 +3424,10 @@ packages:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.5
+    dev: true
+
+  /fast-json-stable-stringify/2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
     dev: true
 
   /fast-levenshtein/2.0.6:
@@ -2673,6 +3456,13 @@ packages:
       is-unicode-supported: 1.3.0
     dev: true
 
+  /file-entry-cache/6.0.1:
+    resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    dependencies:
+      flat-cache: 3.0.4
+    dev: true
+
   /file-uri-to-path/1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
     dev: true
@@ -2684,9 +3474,37 @@ packages:
       to-regex-range: 5.0.1
     dev: true
 
+  /find-up/4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
+    engines: {node: '>=8'}
+    dependencies:
+      locate-path: 5.0.0
+      path-exists: 4.0.0
+    dev: true
+
+  /find-up/5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+    dev: true
+
+  /flat-cache/3.0.4:
+    resolution: {integrity: sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    dependencies:
+      flatted: 3.2.7
+      rimraf: 3.0.2
+    dev: true
+
   /flat/5.0.2:
     resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
     hasBin: true
+    dev: true
+
+  /flatted/3.2.7:
+    resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
     dev: true
 
   /follow-redirects/1.15.2:
@@ -2770,6 +3588,20 @@ packages:
     resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
     dev: true
 
+  /function.prototype.name/1.1.5:
+    resolution: {integrity: sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.1.4
+      es-abstract: 1.20.3
+      functions-have-names: 1.2.3
+    dev: true
+
+  /functions-have-names/1.2.3:
+    resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+    dev: true
+
   /gauge/3.0.2:
     resolution: {integrity: sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==}
     engines: {node: '>=10'}
@@ -2799,6 +3631,14 @@ packages:
     resolution: {integrity: sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==}
     dev: true
 
+  /get-intrinsic/1.1.3:
+    resolution: {integrity: sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==}
+    dependencies:
+      function-bind: 1.1.1
+      has: 1.0.3
+      has-symbols: 1.0.3
+    dev: true
+
   /get-port-please/2.6.1:
     resolution: {integrity: sha512-4PDSrL6+cuMM1xs6w36ZIkaKzzE0xzfVBCfebHIJ3FE8iB9oic/ECwPw3iNiD4h1AoJ5XLLBhEviFAVrZsDC5A==}
     dependencies:
@@ -2808,6 +3648,14 @@ packages:
   /get-stream/6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
+    dev: true
+
+  /get-symbol-description/1.0.0:
+    resolution: {integrity: sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      get-intrinsic: 1.1.3
     dev: true
 
   /git-config-path/2.0.0:
@@ -2843,6 +3691,13 @@ packages:
       is-glob: 4.0.3
     dev: true
 
+  /glob-parent/6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+    dependencies:
+      is-glob: 4.0.3
+    dev: true
+
   /glob/7.1.6:
     resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==}
     dependencies:
@@ -2857,6 +3712,13 @@ packages:
   /globals/11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
+    dev: true
+
+  /globals/13.17.0:
+    resolution: {integrity: sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==}
+    engines: {node: '>=8'}
+    dependencies:
+      type-fest: 0.20.2
     dev: true
 
   /globby/11.1.0:
@@ -2886,6 +3748,10 @@ packages:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
     dev: true
 
+  /grapheme-splitter/1.0.4:
+    resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
+    dev: true
+
   /gzip-size/7.0.0:
     resolution: {integrity: sha512-O1Ld7Dr+nqPnmGpdhzLmMTQ4vAsD+rHwMm1NLUmoUFFymBOMKxCCrtDxqdBRYXdeEPEi3SyoR4TizJLQrnKBNA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -2902,6 +3768,10 @@ packages:
       ufo: 0.8.5
     dev: true
 
+  /has-bigints/1.0.2:
+    resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}
+    dev: true
+
   /has-flag/3.0.0:
     resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
     engines: {node: '>=4'}
@@ -2910,6 +3780,24 @@ packages:
   /has-flag/4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+    dev: true
+
+  /has-property-descriptors/1.0.0:
+    resolution: {integrity: sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==}
+    dependencies:
+      get-intrinsic: 1.1.3
+    dev: true
+
+  /has-symbols/1.0.3:
+    resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
+  /has-tostringtag/1.0.0:
+    resolution: {integrity: sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      has-symbols: 1.0.3
     dev: true
 
   /has-unicode/2.0.1:
@@ -2929,6 +3817,10 @@ packages:
 
   /hookable/5.3.0:
     resolution: {integrity: sha512-4gTA2q08HT8G32uIW7Jpro3rSXgT2ZTM8R6+r7H7joq90eZlqFPPTvHD6w8WZUohIrbXbDperL96ilb6dkNxNw==}
+    dev: true
+
+  /hosted-git-info/2.8.9:
+    resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
     dev: true
 
   /html-encoding-sniffer/3.0.0:
@@ -3033,6 +3925,19 @@ packages:
     engines: {node: '>= 4'}
     dev: true
 
+  /import-fresh/3.3.0:
+    resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
+    engines: {node: '>=6'}
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+    dev: true
+
+  /imurmurhash/0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+    dev: true
+
   /indent-string/4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
@@ -3074,6 +3979,15 @@ packages:
       wrap-ansi: 8.0.1
     dev: true
 
+  /internal-slot/1.0.3:
+    resolution: {integrity: sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      get-intrinsic: 1.1.3
+      has: 1.0.3
+      side-channel: 1.0.4
+    dev: true
+
   /ioredis/5.2.3:
     resolution: {integrity: sha512-gQNcMF23/NpvjCaa1b5YycUyQJ9rBNH2xP94LWinNpodMWVUPP5Ai/xXANn/SM7gfIvI62B5CCvZxhg5pOgyMw==}
     engines: {node: '>=12.22.0'}
@@ -3096,11 +4010,40 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dev: true
 
+  /is-alphabetical/1.0.4:
+    resolution: {integrity: sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==}
+    dev: true
+
+  /is-alphanumerical/1.0.4:
+    resolution: {integrity: sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==}
+    dependencies:
+      is-alphabetical: 1.0.4
+      is-decimal: 1.0.4
+    dev: true
+
+  /is-arrayish/0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+    dev: true
+
+  /is-bigint/1.0.4:
+    resolution: {integrity: sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==}
+    dependencies:
+      has-bigints: 1.0.2
+    dev: true
+
   /is-binary-path/2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
     engines: {node: '>=8'}
     dependencies:
       binary-extensions: 2.2.0
+    dev: true
+
+  /is-boolean-object/1.1.2:
+    resolution: {integrity: sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      has-tostringtag: 1.0.0
     dev: true
 
   /is-builtin-module/3.2.0:
@@ -3110,10 +4053,26 @@ packages:
       builtin-modules: 3.3.0
     dev: true
 
+  /is-callable/1.2.7:
+    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
   /is-core-module/2.10.0:
     resolution: {integrity: sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==}
     dependencies:
       has: 1.0.3
+    dev: true
+
+  /is-date-object/1.0.5:
+    resolution: {integrity: sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      has-tostringtag: 1.0.0
+    dev: true
+
+  /is-decimal/1.0.4:
+    resolution: {integrity: sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==}
     dev: true
 
   /is-docker/2.2.1:
@@ -3150,6 +4109,10 @@ packages:
       is-extglob: 2.1.1
     dev: true
 
+  /is-hexadecimal/1.0.4:
+    resolution: {integrity: sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==}
+    dev: true
+
   /is-interactive/2.0.0:
     resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
     engines: {node: '>=12'}
@@ -3157,6 +4120,18 @@ packages:
 
   /is-module/1.0.0:
     resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
+    dev: true
+
+  /is-negative-zero/2.0.2:
+    resolution: {integrity: sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
+  /is-number-object/1.0.7:
+    resolution: {integrity: sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      has-tostringtag: 1.0.0
     dev: true
 
   /is-number/7.0.0:
@@ -3183,6 +4158,20 @@ packages:
       '@types/estree': 1.0.0
     dev: true
 
+  /is-regex/1.1.4:
+    resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      has-tostringtag: 1.0.0
+    dev: true
+
+  /is-shared-array-buffer/1.0.2:
+    resolution: {integrity: sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==}
+    dependencies:
+      call-bind: 1.0.2
+    dev: true
+
   /is-ssh/1.4.0:
     resolution: {integrity: sha512-x7+VxdxOdlV3CYpjvRLBv5Lo9OJerlYanjwFrPR9fuGPjCiNiCzFgAWpiLAohSbsnH4ZAys3SBh+hq5rJosxUQ==}
     dependencies:
@@ -3199,9 +4188,29 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dev: true
 
+  /is-string/1.0.7:
+    resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      has-tostringtag: 1.0.0
+    dev: true
+
+  /is-symbol/1.0.4:
+    resolution: {integrity: sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      has-symbols: 1.0.3
+    dev: true
+
   /is-unicode-supported/1.3.0:
     resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
     engines: {node: '>=12'}
+    dev: true
+
+  /is-weakref/1.0.2:
+    resolution: {integrity: sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==}
+    dependencies:
+      call-bind: 1.0.2
     dev: true
 
   /is-wsl/2.2.0:
@@ -3238,8 +4247,19 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /js-sdsl/4.1.4:
+    resolution: {integrity: sha512-Y2/yD55y5jteOAmY50JbUZYwk3CP3wnLPEZnlR1w9oKhITrBEtAxwuWKebFf8hMrPMgbYwFoWK/lH2sBkErELw==}
+    dev: true
+
   /js-tokens/4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+    dev: true
+
+  /js-yaml/4.1.0:
+    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+    hasBin: true
+    dependencies:
+      argparse: 2.0.1
     dev: true
 
   /jsdom/20.0.0:
@@ -3290,10 +4310,39 @@ packages:
     hasBin: true
     dev: true
 
+  /json-parse-even-better-errors/2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+    dev: true
+
+  /json-schema-traverse/0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+    dev: true
+
+  /json-stable-stringify-without-jsonify/1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+    dev: true
+
+  /json5/1.0.1:
+    resolution: {integrity: sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==}
+    hasBin: true
+    dependencies:
+      minimist: 1.2.6
+    dev: true
+
   /json5/2.2.1:
     resolution: {integrity: sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==}
     engines: {node: '>=6'}
     hasBin: true
+    dev: true
+
+  /jsonc-eslint-parser/2.1.0:
+    resolution: {integrity: sha512-qCRJWlbP2v6HbmKW7R3lFbeiVWHo+oMJ0j+MizwvauqnCV/EvtAeEeuCgoc/ErtsuoKgYB8U4Ih8AxJbXoE6/g==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      acorn: 8.8.0
+      eslint-visitor-keys: 3.3.0
+      espree: 9.4.0
+      semver: 7.3.7
     dev: true
 
   /jsonc-parser/3.2.0:
@@ -3338,6 +4387,14 @@ packages:
       type-check: 0.3.2
     dev: true
 
+  /levn/0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+    dev: true
+
   /lilconfig/2.0.5:
     resolution: {integrity: sha512-xaYmXZtTHPAw5m+xLN8ab9C+3a8YmV3asNSPOATITbtwrfbwaLJj8h66H1WMIpALCkqsIzK3h7oQ+PdX+LQ9Eg==}
     engines: {node: '>=10'}
@@ -3359,7 +4416,7 @@ packages:
     dependencies:
       cli-truncate: 3.1.0
       colorette: 2.0.19
-      commander: 9.4.0
+      commander: 9.4.1
       debug: 4.3.4
       execa: 6.1.0
       lilconfig: 2.0.5
@@ -3414,7 +4471,7 @@ packages:
       log-update: 4.0.0
       p-map: 4.0.0
       rfdc: 1.3.0
-      rxjs: 7.5.5
+      rxjs: 7.5.6
       through: 2.3.8
       wrap-ansi: 7.0.0
     dev: true
@@ -3427,6 +4484,20 @@ packages:
   /local-pkg/0.4.2:
     resolution: {integrity: sha512-mlERgSPrbxU3BP4qBqAvvwlgW4MTg78iwJdGGnv7kibKjWcJksrG3t6LB5lXI93wXRDvG4NpUgJFmTG4T6rdrg==}
     engines: {node: '>=14'}
+    dev: true
+
+  /locate-path/5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
+    dependencies:
+      p-locate: 4.1.0
+    dev: true
+
+  /locate-path/6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+    dependencies:
+      p-locate: 5.0.0
     dev: true
 
   /lodash._reinterpolate/3.0.0:
@@ -3459,6 +4530,10 @@ packages:
 
   /lodash.memoize/4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
+    dev: true
+
+  /lodash.merge/4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
     dev: true
 
   /lodash.pick/4.4.0:
@@ -3544,6 +4619,22 @@ packages:
       semver: 6.3.0
     dev: true
 
+  /mdast-util-from-markdown/0.8.5:
+    resolution: {integrity: sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==}
+    dependencies:
+      '@types/mdast': 3.0.10
+      mdast-util-to-string: 2.0.0
+      micromark: 2.11.4
+      parse-entities: 2.0.0
+      unist-util-stringify-position: 2.0.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /mdast-util-to-string/2.0.0:
+    resolution: {integrity: sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==}
+    dev: true
+
   /mdn-data/2.0.14:
     resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
     dev: true
@@ -3563,6 +4654,15 @@ packages:
   /merge2/1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+    dev: true
+
+  /micromark/2.11.4:
+    resolution: {integrity: sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==}
+    dependencies:
+      debug: 4.3.4
+      parse-entities: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /micromatch/4.0.5:
@@ -3613,8 +4713,19 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
+  /min-indent/1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+    dev: true
+
   /minimatch/3.0.4:
     resolution: {integrity: sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==}
+    dependencies:
+      brace-expansion: 1.1.11
+    dev: true
+
+  /minimatch/3.1.2:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
       brace-expansion: 1.1.11
     dev: true
@@ -3727,6 +4838,10 @@ packages:
     resolution: {integrity: sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg==}
     engines: {node: ^14 || ^16 || >=18}
     hasBin: true
+    dev: true
+
+  /natural-compare/1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: true
 
   /nitropack/0.5.4_vite@3.1.2:
@@ -3854,6 +4969,15 @@ packages:
       abbrev: 1.1.1
     dev: true
 
+  /normalize-package-data/2.5.0:
+    resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
+    dependencies:
+      hosted-git-info: 2.8.9
+      resolve: 1.22.1
+      semver: 5.7.1
+      validate-npm-package-license: 3.0.4
+    dev: true
+
   /normalize-path/3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
@@ -3906,7 +5030,7 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /nuxt/3.0.0-rc.11_rotfulo2ionxm6wnqfjte3okw4:
+  /nuxt/3.0.0-rc.11_rigehccanlnv2oyjejvvvoyy2u:
     resolution: {integrity: sha512-I0wyxPHnUoJBWoROKUx91PLKaAFZ/TsxSpcm3/jn/Ysq2RGU5Q3o9AzqT0YcXW4rgH35QPFvGpqopU9X0vS7Qw==}
     engines: {node: ^14.16.0 || ^16.11.0 || ^17.0.0 || ^18.0.0}
     hasBin: true
@@ -3916,7 +5040,7 @@ packages:
       '@nuxt/schema': 3.0.0-rc.11_vite@3.1.2
       '@nuxt/telemetry': 2.1.5_vite@3.1.2
       '@nuxt/ui-templates': 0.4.0
-      '@nuxt/vite-builder': 3.0.0-rc.11_arz4dztosvwy2ghjrlh2wdhejm
+      '@nuxt/vite-builder': 3.0.0-rc.11_ywj4bzdq3gzot7ep3achw2p3wa
       '@vue/reactivity': 3.2.39
       '@vue/shared': 3.2.39
       '@vueuse/head': 'link:'
@@ -3984,6 +5108,30 @@ packages:
     resolution: {integrity: sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==}
     dev: true
 
+  /object-keys/1.1.1:
+    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
+  /object.assign/4.1.4:
+    resolution: {integrity: sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.1.4
+      has-symbols: 1.0.3
+      object-keys: 1.1.1
+    dev: true
+
+  /object.values/1.1.5:
+    resolution: {integrity: sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.1.4
+      es-abstract: 1.20.3
+    dev: true
+
   /ohash/0.1.5:
     resolution: {integrity: sha512-qynly1AFIpGWEAW88p6DhMNqok/Swb52/KsiU+Toi7er058Ptvno3tkfTML6wYcEgFgp2GsUziW4Nqn62ciuyw==}
     dev: true
@@ -4045,6 +5193,18 @@ packages:
       word-wrap: 1.2.3
     dev: true
 
+  /optionator/0.9.1:
+    resolution: {integrity: sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.3
+    dev: true
+
   /ora/6.1.2:
     resolution: {integrity: sha512-EJQ3NiP5Xo94wJXIzAyOtSb0QEIAUu7m8t6UZ9krbz0vAJqr92JpcK/lEXg91q6B9pEGqrykkd2EQplnifDSBw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -4065,11 +5225,62 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /p-limit/2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+    dependencies:
+      p-try: 2.2.0
+    dev: true
+
+  /p-limit/3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      yocto-queue: 0.1.0
+    dev: true
+
+  /p-locate/4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
+    dependencies:
+      p-limit: 2.3.0
+    dev: true
+
+  /p-locate/5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+    dependencies:
+      p-limit: 3.1.0
+    dev: true
+
   /p-map/4.0.0:
     resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
     engines: {node: '>=10'}
     dependencies:
       aggregate-error: 3.1.0
+    dev: true
+
+  /p-try/2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
+    dev: true
+
+  /parent-module/1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+    dependencies:
+      callsites: 3.1.0
+    dev: true
+
+  /parse-entities/2.0.0:
+    resolution: {integrity: sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==}
+    dependencies:
+      character-entities: 1.2.4
+      character-entities-legacy: 1.1.4
+      character-reference-invalid: 1.1.4
+      is-alphanumerical: 1.0.4
+      is-decimal: 1.0.4
+      is-hexadecimal: 1.0.4
     dev: true
 
   /parse-git-config/3.0.0:
@@ -4078,6 +5289,16 @@ packages:
     dependencies:
       git-config-path: 2.0.0
       ini: 1.3.8
+    dev: true
+
+  /parse-json/5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@babel/code-frame': 7.18.6
+      error-ex: 1.3.2
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
     dev: true
 
   /parse-path/7.0.0:
@@ -4108,6 +5329,11 @@ packages:
   /parseurl/1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
+    dev: true
+
+  /path-exists/4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
     dev: true
 
   /path-is-absolute/1.0.1:
@@ -4199,6 +5425,11 @@ packages:
     requiresBuild: true
     dependencies:
       playwright-core: 1.25.2
+    dev: true
+
+  /pluralize/8.0.0:
+    resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
+    engines: {node: '>=4'}
     dev: true
 
   /postcss-calc/8.2.4_postcss@8.4.16:
@@ -4555,10 +5786,9 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /prettier/2.7.1:
-    resolution: {integrity: sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
+  /prelude-ls/1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
     dev: true
 
   /pretty-bytes/6.0.0:
@@ -4624,6 +5854,25 @@ packages:
       pify: 2.3.0
     dev: true
 
+  /read-pkg-up/7.0.1:
+    resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==}
+    engines: {node: '>=8'}
+    dependencies:
+      find-up: 4.1.0
+      read-pkg: 5.2.0
+      type-fest: 0.8.1
+    dev: true
+
+  /read-pkg/5.2.0:
+    resolution: {integrity: sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@types/normalize-package-data': 2.4.1
+      normalize-package-data: 2.5.0
+      parse-json: 5.2.0
+      type-fest: 0.6.0
+    dev: true
+
   /readable-stream/2.3.7:
     resolution: {integrity: sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==}
     dependencies:
@@ -4670,6 +5919,25 @@ packages:
       redis-errors: 1.2.0
     dev: true
 
+  /regexp-tree/0.1.24:
+    resolution: {integrity: sha512-s2aEVuLhvnVJW6s/iPgEGK6R+/xngd2jNQ+xy4bXNDKxZKJH6jpPHY6kVeVv1IeLCHgswRj+Kl3ELaDjG6V1iw==}
+    hasBin: true
+    dev: true
+
+  /regexp.prototype.flags/1.4.3:
+    resolution: {integrity: sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.1.4
+      functions-have-names: 1.2.3
+    dev: true
+
+  /regexpp/3.2.0:
+    resolution: {integrity: sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==}
+    engines: {node: '>=8'}
+    dev: true
+
   /require-directory/2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -4677,6 +5945,11 @@ packages:
 
   /requires-port/1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+    dev: true
+
+  /resolve-from/4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
     dev: true
 
   /resolve-from/5.0.0:
@@ -4787,12 +6060,6 @@ packages:
       queue-microtask: 1.2.3
     dev: true
 
-  /rxjs/7.5.5:
-    resolution: {integrity: sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==}
-    dependencies:
-      tslib: 2.1.0
-    dev: true
-
   /rxjs/7.5.6:
     resolution: {integrity: sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==}
     dependencies:
@@ -4805,6 +6072,20 @@ packages:
 
   /safe-buffer/5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+    dev: true
+
+  /safe-regex-test/1.0.0:
+    resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
+    dependencies:
+      call-bind: 1.0.2
+      get-intrinsic: 1.1.3
+      is-regex: 1.1.4
+    dev: true
+
+  /safe-regex/2.1.1:
+    resolution: {integrity: sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==}
+    dependencies:
+      regexp-tree: 0.1.24
     dev: true
 
   /safer-buffer/2.1.2:
@@ -4827,6 +6108,11 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       node-forge: 1.3.1
+    dev: true
+
+  /semver/5.7.1:
+    resolution: {integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==}
+    hasBin: true
     dev: true
 
   /semver/6.3.0:
@@ -4907,6 +6193,14 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /side-channel/1.0.4:
+    resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
+    dependencies:
+      call-bind: 1.0.2
+      get-intrinsic: 1.1.3
+      object-inspect: 1.12.2
+    dev: true
+
   /signal-exit/3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
     dev: true
@@ -4983,6 +6277,28 @@ packages:
   /sourcemap-codec/1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
 
+  /spdx-correct/3.1.1:
+    resolution: {integrity: sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==}
+    dependencies:
+      spdx-expression-parse: 3.0.1
+      spdx-license-ids: 3.0.12
+    dev: true
+
+  /spdx-exceptions/2.3.0:
+    resolution: {integrity: sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==}
+    dev: true
+
+  /spdx-expression-parse/3.0.1:
+    resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
+    dependencies:
+      spdx-exceptions: 2.3.0
+      spdx-license-ids: 3.0.12
+    dev: true
+
+  /spdx-license-ids/3.0.12:
+    resolution: {integrity: sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==}
+    dev: true
+
   /stable/0.1.8:
     resolution: {integrity: sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==}
     deprecated: 'Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility'
@@ -5024,6 +6340,22 @@ packages:
       strip-ansi: 7.0.1
     dev: true
 
+  /string.prototype.trimend/1.0.5:
+    resolution: {integrity: sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.1.4
+      es-abstract: 1.20.3
+    dev: true
+
+  /string.prototype.trimstart/1.0.5:
+    resolution: {integrity: sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.1.4
+      es-abstract: 1.20.3
+    dev: true
+
   /string_decoder/1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
     dependencies:
@@ -5044,6 +6376,11 @@ packages:
       ansi-regex: 6.0.1
     dev: true
 
+  /strip-bom/3.0.0:
+    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
+    engines: {node: '>=4'}
+    dev: true
+
   /strip-final-newline/2.0.0:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
@@ -5052,6 +6389,18 @@ packages:
   /strip-final-newline/3.0.0:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
     engines: {node: '>=12'}
+    dev: true
+
+  /strip-indent/3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      min-indent: 1.0.1
+    dev: true
+
+  /strip-json-comments/3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
     dev: true
 
   /strip-literal/0.4.1:
@@ -5188,6 +6537,10 @@ packages:
       source-map-support: 0.5.21
     dev: true
 
+  /text-table/0.2.0:
+    resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
+    dev: true
+
   /thenify-all/1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
     engines: {node: '>=0.8'}
@@ -5282,6 +6635,19 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
+  /tsconfig-paths/3.14.1:
+    resolution: {integrity: sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==}
+    dependencies:
+      '@types/json5': 0.0.29
+      json5: 1.0.1
+      minimist: 1.2.6
+      strip-bom: 3.0.0
+    dev: true
+
+  /tslib/1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+    dev: true
+
   /tslib/2.1.0:
     resolution: {integrity: sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==}
     dev: true
@@ -5322,6 +6688,16 @@ packages:
       - ts-node
     dev: true
 
+  /tsutils/3.21.0_typescript@4.8.3:
+    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
+    engines: {node: '>= 6'}
+    peerDependencies:
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+    dependencies:
+      tslib: 1.14.1
+      typescript: 4.8.3
+    dev: true
+
   /type-check/0.3.2:
     resolution: {integrity: sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==}
     engines: {node: '>= 0.8.0'}
@@ -5329,14 +6705,36 @@ packages:
       prelude-ls: 1.1.2
     dev: true
 
+  /type-check/0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      prelude-ls: 1.2.1
+    dev: true
+
   /type-detect/4.0.8:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
     engines: {node: '>=4'}
     dev: true
 
+  /type-fest/0.20.2:
+    resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
+    engines: {node: '>=10'}
+    dev: true
+
   /type-fest/0.21.3:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
+    dev: true
+
+  /type-fest/0.6.0:
+    resolution: {integrity: sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /type-fest/0.8.1:
+    resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
+    engines: {node: '>=8'}
     dev: true
 
   /type-fest/1.4.0:
@@ -5357,6 +6755,15 @@ packages:
 
   /ufo/0.8.5:
     resolution: {integrity: sha512-e4+UtA5IRO+ha6hYklwj6r7BjiGMxS0O+UaSg9HbaTefg4kMkzj4tXzEBajRR+wkxf+golgAWKzLbytCUDMJAA==}
+    dev: true
+
+  /unbox-primitive/1.0.2:
+    resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
+    dependencies:
+      call-bind: 1.0.2
+      has-bigints: 1.0.2
+      has-symbols: 1.0.3
+      which-boxed-primitive: 1.0.2
     dev: true
 
   /unctx/2.0.2_vite@3.1.2:
@@ -5459,6 +6866,12 @@ packages:
       - rollup
       - vite
       - webpack
+    dev: true
+
+  /unist-util-stringify-position/2.0.3:
+    resolution: {integrity: sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==}
+    dependencies:
+      '@types/unist': 2.0.6
     dev: true
 
   /universalify/0.2.0:
@@ -5588,6 +7001,12 @@ packages:
       picocolors: 1.0.0
     dev: true
 
+  /uri-js/4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+    dependencies:
+      punycode: 2.1.1
+    dev: true
+
   /url-parse/1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
     dependencies:
@@ -5597,6 +7016,13 @@ packages:
 
   /util-deprecate/1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+    dev: true
+
+  /validate-npm-package-license/3.0.4:
+    resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+    dependencies:
+      spdx-correct: 3.1.1
+      spdx-expression-parse: 3.0.1
     dev: true
 
   /vite-node/0.23.4:
@@ -5616,7 +7042,7 @@ packages:
       - terser
     dev: true
 
-  /vite-plugin-checker/0.5.1_nijwsw6kalmosfobgutypnhyhi:
+  /vite-plugin-checker/0.5.1_dtveubzuwdz4s34cbjaxelqvm4:
     resolution: {integrity: sha512-NFiO1PyK9yGuaeSnJ7Whw9fnxLc1AlELnZoyFURnauBYhbIkx9n+PmIXxSFUuC9iFyACtbJQUAEuQi6yHs2Adg==}
     engines: {node: '>=14.16'}
     peerDependencies:
@@ -5640,6 +7066,7 @@ packages:
       chalk: 4.1.2
       chokidar: 3.5.3
       commander: 8.3.0
+      eslint: 8.24.0
       fast-glob: 3.2.12
       lodash.debounce: 4.0.8
       lodash.pick: 4.4.0
@@ -5815,6 +7242,24 @@ packages:
     resolution: {integrity: sha512-RutnB7X8c5hjq39NceArgXg28WZtZpGc3+J16ljMiYnFhKvd8hITxSWQSQ5bvldxMDU6gG5mkxl1MTQLXckVSQ==}
     dev: true
 
+  /vue-eslint-parser/9.1.0_eslint@8.24.0:
+    resolution: {integrity: sha512-NGn/iQy8/Wb7RrRa4aRkokyCZfOUWk19OP5HP6JEozQFX5AoS/t+Z0ZN7FY4LlmWc4FNI922V7cvX28zctN8dQ==}
+    engines: {node: ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '>=6.0.0'
+    dependencies:
+      debug: 4.3.4
+      eslint: 8.24.0
+      eslint-scope: 7.1.1
+      eslint-visitor-keys: 3.3.0
+      espree: 9.4.0
+      esquery: 1.4.0
+      lodash: 4.17.21
+      semver: 7.3.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /vue-router/4.1.5_vue@3.2.39:
     resolution: {integrity: sha512-IsvoF5D2GQ/EGTs/Th4NQms9gd2NSqV+yylxIyp/OYp8xOwxmU8Kj/74E9DTSYAyH5LX7idVUngN3JSj1X4xcQ==}
     peerDependencies:
@@ -5914,6 +7359,16 @@ packages:
       webidl-conversions: 4.0.2
     dev: true
 
+  /which-boxed-primitive/1.0.2:
+    resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}
+    dependencies:
+      is-bigint: 1.0.4
+      is-boolean-object: 1.1.2
+      is-number-object: 1.0.7
+      is-string: 1.0.7
+      is-symbol: 1.0.4
+    dev: true
+
   /which/2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -6005,6 +7460,15 @@ packages:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
     dev: true
 
+  /yaml-eslint-parser/1.1.0:
+    resolution: {integrity: sha512-b464Q1fYiX1oYx2kE8k4mEp6S9Prk+tfDsY/IPxQ0FCjEuj3AKko5Skf3/yQJeYTTDyjDE+aWIJemnv29HvEWQ==}
+    engines: {node: ^14.17.0 || >=16.0.0}
+    dependencies:
+      eslint-visitor-keys: 3.3.0
+      lodash: 4.17.21
+      yaml: 2.1.1
+    dev: true
+
   /yaml/1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
@@ -6031,6 +7495,11 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+    dev: true
+
+  /yocto-queue/0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
     dev: true
 
   /zip-stream/4.1.0:

--- a/src/components.ts
+++ b/src/components.ts
@@ -1,0 +1,93 @@
+import type { Ref, VNode } from 'vue'
+import { defineComponent, onBeforeUnmount, ref, watchEffect } from 'vue'
+import type { HeadObjectPlain } from './types'
+import type { HeadAttrs } from './index'
+import { injectHead } from './index'
+
+const addVNodeToHeadObj = (node: VNode, obj: HeadObjectPlain) => {
+  const type
+    = node.type === 'html'
+      ? 'htmlAttrs'
+      : node.type === 'body'
+        ? 'bodyAttrs'
+        : (node.type as keyof HeadObjectPlain)
+
+  if (typeof type !== 'string' || !(type in obj))
+    return
+
+  const props = {
+    ...node.props,
+    children: Array.isArray(node.children)
+      ? node.children[0]!.children
+      : node.children,
+  } as HeadAttrs
+  if (Array.isArray(obj[type]))
+    (obj[type] as HeadAttrs[]).push(props)
+
+  else if (type === 'title')
+    obj.title = props.children
+
+  else
+    (obj[type] as HeadAttrs) = props
+}
+
+const vnodesToHeadObj = (nodes: VNode[]) => {
+  const obj: HeadObjectPlain = {
+    title: undefined,
+    htmlAttrs: undefined,
+    bodyAttrs: undefined,
+    base: undefined,
+    meta: [],
+    link: [],
+    style: [],
+    script: [],
+    noscript: [],
+  }
+
+  for (const node of nodes) {
+    if (typeof node.type === 'symbol' && Array.isArray(node.children)) {
+      for (const childNode of node.children)
+        addVNodeToHeadObj(childNode as VNode, obj)
+    }
+    else {
+      addVNodeToHeadObj(node, obj)
+    }
+  }
+
+  return obj
+}
+
+export const Head = /* @__PURE__ */ defineComponent({
+  // eslint-disable-next-line vue/no-reserved-component-names
+  name: 'Head',
+
+  setup(_, { slots }) {
+    const head = injectHead()
+
+    let obj: Ref<HeadObjectPlain>
+
+    onBeforeUnmount(() => {
+      // eslint-disable-next-line vue/no-ref-as-operand
+      if (obj) {
+        head.removeHeadObjs(obj)
+        head.updateDOM()
+      }
+    })
+
+    return () => {
+      watchEffect(() => {
+        if (!slots.default)
+          return
+        // eslint-disable-next-line vue/no-ref-as-operand
+        if (obj)
+          head.removeHeadObjs(obj)
+        // eslint-disable-next-line vue/no-ref-as-operand
+        obj = ref(vnodesToHeadObj(slots.default()))
+        head.addHeadObjs(obj)
+        if (typeof window !== 'undefined')
+          head.updateDOM()
+      })
+      return null
+    }
+  },
+})

--- a/src/components.ts
+++ b/src/components.ts
@@ -18,6 +18,7 @@ const addVNodeToHeadObj = (node: VNode, obj: HeadObjectPlain) => {
   const props = {
     ...node.props,
     children: Array.isArray(node.children)
+      // @ts-expect-error untyped
       ? node.children[0]!.children
       : node.children,
   } as HeadAttrs

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,8 +1,8 @@
-export const PROVIDE_KEY = `usehead`
-export const HEAD_COUNT_KEY = `head:count`
+export const PROVIDE_KEY = 'usehead'
+export const HEAD_COUNT_KEY = 'head:count'
 // Store attr names for `htmlAttrs`, `bodyAttrs` so we can remove them first before next update
-export const HEAD_ATTRS_KEY = `data-head-attrs`
+export const HEAD_ATTRS_KEY = 'data-head-attrs'
 
-export const SELF_CLOSING_TAGS = ["meta", "link", "base"]
+export const SELF_CLOSING_TAGS = ['meta', 'link', 'base']
 
-export const BODY_TAG_ATTR_NAME = `data-meta-body`
+export const BODY_TAG_ATTR_NAME = 'data-meta-body'

--- a/src/create-element.ts
+++ b/src/create-element.ts
@@ -1,4 +1,4 @@
-import { BODY_TAG_ATTR_NAME } from "./constants"
+import { BODY_TAG_ATTR_NAME } from './constants'
 
 export const createElement = (
   tag: string,
@@ -8,21 +8,20 @@ export const createElement = (
   const el = document.createElement(tag)
 
   for (const key of Object.keys(attrs)) {
-    if (key === "body" && attrs.body === true) {
+    if (key === 'body' && attrs.body === true) {
       // set meta-body attribute to add the tag before </body>
-      el.setAttribute(BODY_TAG_ATTR_NAME, "true")
-    } else {
-      let value = attrs[key]
+      el.setAttribute(BODY_TAG_ATTR_NAME, 'true')
+    }
+    else {
+      const value = attrs[key]
 
-      if (key === "renderPriority" || key === "key" || value === false) {
+      if (key === 'renderPriority' || key === 'key' || value === false)
         continue
-      }
 
-      if (key === "children") {
+      if (key === 'children')
         el.textContent = value
-      } else {
+      else
         el.setAttribute(key, value)
-      }
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,51 +1,51 @@
-import {
+import type {
   App,
-  defineComponent,
+  Ref,
+} from 'vue'
+import {
   inject,
   onBeforeUnmount,
   ref,
-  Ref,
-  watchEffect,
-  VNode,
-  unref,
   shallowRef,
-} from "vue"
+  unref,
+  watchEffect,
+} from 'vue'
 import {
-  PROVIDE_KEY,
-  HEAD_COUNT_KEY,
-  HEAD_ATTRS_KEY,
-  SELF_CLOSING_TAGS,
   BODY_TAG_ATTR_NAME,
-} from "./constants"
-import { createElement } from "./create-element"
-import { stringifyAttrs } from "./stringify-attrs"
-import { isEqualNode } from "./utils"
+  HEAD_ATTRS_KEY,
+  HEAD_COUNT_KEY,
+  PROVIDE_KEY,
+  SELF_CLOSING_TAGS,
+} from './constants'
+import { createElement } from './create-element'
+import { stringifyAttrs } from './stringify-attrs'
+import { isEqualNode, sortTags } from './utils'
 import type {
-  HeadObjectPlain,
-  HeadObject,
-  TagKeys,
+  HandlesDuplicates,
   HasRenderPriority,
-} from "./types"
-import { HandlesDuplicates, RendersInnerContent, RendersToBody } from "./types"
+  HeadObject,
+  HeadObjectPlain,
+  RendersInnerContent, RendersToBody, TagKeys,
+} from './types'
 
-export * from "./types"
+export * from './types'
 
 type MaybeRef<T> = T | Ref<T>
 
-export type HeadAttrs = { [k: string]: any }
+export interface HeadAttrs { [k: string]: any }
 
-export type HeadTag = {
+export interface HeadTag {
   tag: TagKeys
   props: HandlesDuplicates &
-    HasRenderPriority &
-    RendersToBody &
-    RendersInnerContent & {
-      [k: string]: any
-    }
+  HasRenderPriority &
+  RendersToBody &
+  RendersInnerContent & {
+    [k: string]: any
+  }
   _position?: number
 }
 
-export type HeadClient = {
+export interface HeadClient {
   install: (app: App) => void
 
   headTags: HeadTag[]
@@ -70,31 +70,31 @@ export interface HTMLResult {
 
 const tagDedupeKey = <T extends HeadTag>(tag: T) => {
   // only meta, base and script tags will be deduped
-  if (!["meta", "base", "script", "link"].includes(tag.tag)) {
+  if (!['meta', 'base', 'script', 'link'].includes(tag.tag))
     return false
-  }
+
   const { props, tag: tagName } = tag
   // must only be a single base so we always dedupe
-  if (tagName === "base") {
-    return "base"
-  }
+  if (tagName === 'base')
+    return 'base'
+
   // support only a single canonical
-  if (tagName === "link" && props.rel === "canonical") {
-    return "canonical"
-  }
+  if (tagName === 'link' && props.rel === 'canonical')
+    return 'canonical'
+
   // must only be a single charset
-  if (props.charset) {
-    return "charset"
-  }
-  const name = ["key", "id", "name", "property", "http-equiv"]
+  if (props.charset)
+    return 'charset'
+
+  const name = ['key', 'id', 'name', 'property', 'http-equiv']
   for (const n of name) {
-    let value = undefined
+    let value
     // Probably an HTML Element
-    if (typeof props.getAttribute === "function" && props.hasAttribute(n)) {
+    if (typeof props.getAttribute === 'function' && props.hasAttribute(n))
       value = props.getAttribute(n)
-    } else {
+    else
       value = props[n]
-    }
+
     if (value !== undefined) {
       // for example: meta-name-description
       return `${tagName}-${n}-${value}`
@@ -110,33 +110,33 @@ const tagDedupeKey = <T extends HeadTag>(tag: T) => {
 export const injectHead = () => {
   const head = inject<HeadClient>(PROVIDE_KEY)
 
-  if (!head) {
-    throw new Error(`You may forget to apply app.use(head)`)
-  }
+  if (!head)
+    throw new Error('You may forget to apply app.use(head)')
 
   return head
 }
 
 const acceptFields: Array<TagKeys> = [
-  "title",
-  "meta",
-  "link",
-  "base",
-  "style",
-  "script",
-  "noscript",
-  "htmlAttrs",
-  "bodyAttrs",
+  'title',
+  'meta',
+  'link',
+  'base',
+  'style',
+  'script',
+  'noscript',
+  'htmlAttrs',
+  'bodyAttrs',
 ]
 
 const renderTemplate = (
-  template: Required<HeadObjectPlain>["titleTemplate"],
+  template: Required<HeadObjectPlain>['titleTemplate'],
   title?: string,
 ): string => {
-  if (template == null) return ""
-  if (typeof template === "string") {
-    return template.replace("%s", title ?? "")
-  }
+  if (template == null)
+    return ''
+  if (typeof template === 'string')
+    return template.replace('%s', title ?? '')
+
   return template(unref(title))
 }
 
@@ -157,16 +157,17 @@ const headObjToTags = (obj: HeadObjectPlain) => {
   }
 
   for (const key of keys) {
-    if (obj[key] == null) continue
+    if (obj[key] == null)
+      continue
 
     switch (key) {
-      case "title":
+      case 'title':
         tags.push({ tag: key, props: { children: obj[key] } })
         break
-      case "titleTemplate":
+      case 'titleTemplate':
         break
-      case "base":
-        tags.push({ tag: key, props: { key: "default", ...obj[key] } })
+      case 'base':
+        tags.push({ tag: key, props: { key: 'default', ...obj[key] } })
         break
       default:
         if (acceptFields.includes(key)) {
@@ -177,7 +178,8 @@ const headObjToTags = (obj: HeadObjectPlain) => {
               // unref item to support ref array entries
               tags.push({ tag: key, props })
             })
-          } else if (value) {
+          }
+          else if (value) {
             tags.push({ tag: key, props: convertLegacyKey(value) })
           }
         }
@@ -191,10 +193,9 @@ const headObjToTags = (obj: HeadObjectPlain) => {
 const setAttrs = (el: Element, attrs: HeadAttrs) => {
   const existingAttrs = el.getAttribute(HEAD_ATTRS_KEY)
   if (existingAttrs) {
-    for (const key of existingAttrs.split(",")) {
-      if (!(key in attrs)) {
+    for (const key of existingAttrs.split(',')) {
+      if (!(key in attrs))
         el.removeAttribute(key)
-      }
     }
   }
 
@@ -202,22 +203,21 @@ const setAttrs = (el: Element, attrs: HeadAttrs) => {
 
   for (const key in attrs) {
     const value = attrs[key]
-    if (value == null) continue
+    if (value == null)
+      continue
 
-    if (value === false) {
+    if (value === false)
       el.removeAttribute(key)
-    } else {
+    else
       el.setAttribute(key, value)
-    }
 
     keys.push(key)
   }
 
-  if (keys.length) {
-    el.setAttribute(HEAD_ATTRS_KEY, keys.join(","))
-  } else {
+  if (keys.length)
+    el.setAttribute(HEAD_ATTRS_KEY, keys.join(','))
+  else
     el.removeAttribute(HEAD_ATTRS_KEY)
-  }
 }
 
 const updateElements = (
@@ -228,9 +228,9 @@ const updateElements = (
   const head = document.head
   const body = document.body
   let headCountEl = head.querySelector(`meta[name="${HEAD_COUNT_KEY}"]`)
-  let bodyMetaElements = body.querySelectorAll(`[${BODY_TAG_ATTR_NAME}]`)
+  const bodyMetaElements = body.querySelectorAll(`[${BODY_TAG_ATTR_NAME}]`)
   const headCount = headCountEl
-    ? Number(headCountEl.getAttribute("content"))
+    ? Number(headCountEl.getAttribute('content'))
     : 0
   const oldHeadElements: Element[] = []
   const oldBodyElements: Element[] = []
@@ -238,11 +238,10 @@ const updateElements = (
   if (bodyMetaElements) {
     for (let i = 0; i < bodyMetaElements.length; i++) {
       if (
-        bodyMetaElements[i] &&
-        bodyMetaElements[i].tagName?.toLowerCase() === type
-      ) {
+        bodyMetaElements[i]
+        && bodyMetaElements[i].tagName?.toLowerCase() === type
+      )
         oldBodyElements.push(bodyMetaElements[i])
-      }
     }
   }
   if (headCountEl) {
@@ -251,17 +250,17 @@ const updateElements = (
       i < headCount;
       i++, j = j?.previousElementSibling || null
     ) {
-      if (j?.tagName?.toLowerCase() === type) {
+      if (j?.tagName?.toLowerCase() === type)
         oldHeadElements.push(j)
-      }
     }
-  } else {
-    headCountEl = document.createElement("meta")
-    headCountEl.setAttribute("name", HEAD_COUNT_KEY)
-    headCountEl.setAttribute("content", "0")
+  }
+  else {
+    headCountEl = document.createElement('meta')
+    headCountEl.setAttribute('name', HEAD_COUNT_KEY)
+    headCountEl.setAttribute('content', '0')
     head.append(headCountEl)
   }
-  let newElements = tags.map((tag) => ({
+  let newElements = tags.map(tag => ({
     element: createElement(tag.tag, tag.props, document),
     body: tag.props.body ?? false,
   }))
@@ -284,31 +283,29 @@ const updateElements = (
     return true
   })
 
-  oldBodyElements.forEach((t) => t.parentNode?.removeChild(t))
-  oldHeadElements.forEach((t) => t.parentNode?.removeChild(t))
+  oldBodyElements.forEach(t => t.parentNode?.removeChild(t))
+  oldHeadElements.forEach(t => t.parentNode?.removeChild(t))
   newElements.forEach((t) => {
-    if (t.body === true) {
-      body.insertAdjacentElement("beforeend", t.element)
-    } else {
+    if (t.body === true)
+      body.insertAdjacentElement('beforeend', t.element)
+    else
       head.insertBefore(t.element, headCountEl)
-    }
   })
   headCountEl.setAttribute(
-    "content",
-    "" +
-      (headCount -
-        oldHeadElements.length +
-        newElements.filter((t) => !t.body).length),
+    'content',
+    `${
+      headCount
+        - oldHeadElements.length
+        + newElements.filter(t => !t.body).length}`,
   )
 }
 
 export const createHead = (initHeadObject?: MaybeRef<HeadObjectPlain>) => {
   let allHeadObjs: Ref<HeadObjectPlain>[] = []
-  let previousTags = new Set<string>()
+  const previousTags = new Set<string>()
 
-  if (initHeadObject) {
+  if (initHeadObject)
     allHeadObjs.push(shallowRef(initHeadObject))
-  }
 
   const head: HeadClient = {
     install(app) {
@@ -323,9 +320,9 @@ export const createHead = (initHeadObject?: MaybeRef<HeadObjectPlain>) => {
       const deduping: Record<string, HeadTag> = {}
 
       const titleTemplate = allHeadObjs
-        .map((i) => unref(i).titleTemplate)
+        .map(i => unref(i).titleTemplate)
         .reverse()
-        .find((i) => i != null)
+        .find(i => i != null)
 
       allHeadObjs.forEach((objs, headObjectIdx) => {
         const tags = headObjToTags(unref(objs))
@@ -335,7 +332,7 @@ export const createHead = (initHeadObject?: MaybeRef<HeadObjectPlain>) => {
           // ideally we'd use the total tag count but this is too hard to calculate with the current reactivity
           tag._position = headObjectIdx * 10000 + tagIdx
           // resolve titles
-          if (titleTemplate && tag.tag === "title") {
+          if (titleTemplate && tag.tag === 'title') {
             tag.props.children = renderTemplate(
               titleTemplate,
               tag.props.children,
@@ -343,11 +340,10 @@ export const createHead = (initHeadObject?: MaybeRef<HeadObjectPlain>) => {
           }
           // Remove tags with the same key
           const dedupeKey = tagDedupeKey(tag)
-          if (dedupeKey) {
+          if (dedupeKey)
             deduping[dedupeKey] = tag
-          } else {
+          else
             deduped.push(tag)
-          }
         })
       })
 
@@ -362,27 +358,27 @@ export const createHead = (initHeadObject?: MaybeRef<HeadObjectPlain>) => {
     },
 
     removeHeadObjs(objs) {
-      allHeadObjs = allHeadObjs.filter((_objs) => _objs !== objs)
+      allHeadObjs = allHeadObjs.filter(_objs => _objs !== objs)
     },
 
     updateDOM(document = window.document) {
       let title: string | undefined
-      let htmlAttrs: HeadAttrs = {}
-      let bodyAttrs: HeadAttrs = {}
+      const htmlAttrs: HeadAttrs = {}
+      const bodyAttrs: HeadAttrs = {}
 
       const actualTags: Record<string, HeadTag[]> = {}
 
       // head sorting here is not guaranteed to be honoured
       for (const tag of head.headTags.sort(sortTags)) {
-        if (tag.tag === "title") {
+        if (tag.tag === 'title') {
           title = tag.props.children
           continue
         }
-        if (tag.tag === "htmlAttrs") {
+        if (tag.tag === 'htmlAttrs') {
           Object.assign(htmlAttrs, tag.props)
           continue
         }
-        if (tag.tag === "bodyAttrs") {
+        if (tag.tag === 'bodyAttrs') {
           Object.assign(bodyAttrs, tag.props)
           continue
         }
@@ -391,23 +387,23 @@ export const createHead = (initHeadObject?: MaybeRef<HeadObjectPlain>) => {
         actualTags[tag.tag].push(tag)
       }
 
-      if (title !== undefined) {
+      if (title !== undefined)
         document.title = title
-      }
+
       setAttrs(document.documentElement, htmlAttrs)
       setAttrs(document.body, bodyAttrs)
       const tags = new Set([...Object.keys(actualTags), ...previousTags])
-      for (const tag of tags) {
+      for (const tag of tags)
         updateElements(document, tag, actualTags[tag] || [])
-      }
+
       previousTags.clear()
-      Object.keys(actualTags).forEach((i) => previousTags.add(i))
+      Object.keys(actualTags).forEach(i => previousTags.add(i))
     },
   }
   return head
 }
 
-const IS_BROWSER = typeof window !== "undefined"
+const IS_BROWSER = typeof window !== 'undefined'
 
 export const useHead = (obj: MaybeRef<HeadObject>) => {
   const head = injectHead()
@@ -434,172 +430,62 @@ const tagToString = (tag: HeadTag) => {
     // avoid rendering body attr
     delete tag.props.body
   }
-  if (tag.props.renderPriority) {
+  if (tag.props.renderPriority)
     delete tag.props.renderPriority
-  }
-  let attrs = stringifyAttrs(tag.props)
+
+  const attrs = stringifyAttrs(tag.props)
   if (SELF_CLOSING_TAGS.includes(tag.tag)) {
     return `<${tag.tag}${attrs}${
-      isBodyTag ? " " + ` ${BODY_TAG_ATTR_NAME}="true"` : ""
+      isBodyTag ? ' ' + ` ${BODY_TAG_ATTR_NAME}="true"` : ''
     }>`
   }
 
   return `<${tag.tag}${attrs}${
-    isBodyTag ? ` ${BODY_TAG_ATTR_NAME}="true"` : ""
-  }>${tag.props.children || ""}</${tag.tag}>`
-}
-
-const sortTags = (aTag: HeadTag, bTag: HeadTag) => {
-  const tagWeight = (tag: HeadTag) => {
-    if (tag.props.renderPriority) {
-      return tag.props.renderPriority
-    }
-    switch (tag.tag) {
-      // This element must come before other elements with attribute values of URLs
-      case "base":
-        return -1
-      case "meta":
-        // charset must come early in case there's non-utf8 characters in the HTML document
-        if (tag.props.charset) {
-          return -2
-        }
-        // CSP needs to be as it effects the loading of assets
-        if (tag.props["http-equiv"] === "content-security-policy") {
-          return 0
-        }
-        return 10
-      default:
-        // arbitrary safe number that can go up and down without conflicting
-        return 10
-    }
-  }
-  return tagWeight(aTag) - tagWeight(bTag)
+    isBodyTag ? ` ${BODY_TAG_ATTR_NAME}="true"` : ''
+  }>${tag.props.children || ''}</${tag.tag}>`
 }
 
 export const renderHeadToString = (head: HeadClient): HTMLResult => {
   const tags: string[] = []
-  let titleTag = ""
-  let htmlAttrs: HeadAttrs = {}
-  let bodyAttrs: HeadAttrs = {}
-  let bodyTags: string[] = []
+  let titleTag = ''
+  const htmlAttrs: HeadAttrs = {}
+  const bodyAttrs: HeadAttrs = {}
+  const bodyTags: string[] = []
 
   for (const tag of head.headTags.sort(sortTags)) {
-    if (tag.tag === "title") {
+    if (tag.tag === 'title')
       titleTag = tagToString(tag)
-    } else if (tag.tag === "htmlAttrs") {
+    else if (tag.tag === 'htmlAttrs')
       Object.assign(htmlAttrs, tag.props)
-    } else if (tag.tag === "bodyAttrs") {
+    else if (tag.tag === 'bodyAttrs')
       Object.assign(bodyAttrs, tag.props)
-    } else if (tag.props.body) {
+    else if (tag.props.body)
       bodyTags.push(tagToString(tag))
-    } else {
+    else
       tags.push(tagToString(tag))
-    }
   }
   tags.push(`<meta name="${HEAD_COUNT_KEY}" content="${tags.length}">`)
 
   return {
     get headTags() {
-      return titleTag + tags.join("")
+      return titleTag + tags.join('')
     },
     get htmlAttrs() {
       return stringifyAttrs({
         ...htmlAttrs,
-        [HEAD_ATTRS_KEY]: Object.keys(htmlAttrs).join(","),
+        [HEAD_ATTRS_KEY]: Object.keys(htmlAttrs).join(','),
       })
     },
     get bodyAttrs() {
       return stringifyAttrs({
         ...bodyAttrs,
-        [HEAD_ATTRS_KEY]: Object.keys(bodyAttrs).join(","),
+        [HEAD_ATTRS_KEY]: Object.keys(bodyAttrs).join(','),
       })
     },
     get bodyTags() {
-      return bodyTags.join("")
+      return bodyTags.join('')
     },
   }
 }
 
-const addVNodeToHeadObj = (node: VNode, obj: HeadObjectPlain) => {
-  const type =
-    node.type === "html"
-      ? "htmlAttrs"
-      : node.type === "body"
-      ? "bodyAttrs"
-      : (node.type as keyof HeadObjectPlain)
-
-  if (typeof type !== "string" || !(type in obj)) return
-
-  const props = {
-    ...node.props,
-    children: Array.isArray(node.children)
-      ? // @ts-expect-error
-        node.children[0]!.children
-      : node.children,
-  } as HeadAttrs
-  if (Array.isArray(obj[type])) {
-    ;(obj[type] as HeadAttrs[]).push(props)
-  } else if (type === "title") {
-    obj.title = props.children
-  } else {
-    ;(obj[type] as HeadAttrs) = props
-  }
-}
-
-const vnodesToHeadObj = (nodes: VNode[]) => {
-  const obj: HeadObjectPlain = {
-    title: undefined,
-    htmlAttrs: undefined,
-    bodyAttrs: undefined,
-    base: undefined,
-    meta: [],
-    link: [],
-    style: [],
-    script: [],
-    noscript: [],
-  }
-
-  for (const node of nodes) {
-    if (typeof node.type === "symbol" && Array.isArray(node.children)) {
-      for (const childNode of node.children) {
-        addVNodeToHeadObj(childNode as VNode, obj)
-      }
-    } else {
-      addVNodeToHeadObj(node, obj)
-    }
-  }
-
-  return obj
-}
-
-export const Head = /*@__PURE__*/ defineComponent({
-  name: "Head",
-
-  setup(_, { slots }) {
-    const head = injectHead()
-
-    let obj: Ref<HeadObjectPlain> | undefined
-
-    onBeforeUnmount(() => {
-      if (obj) {
-        head.removeHeadObjs(obj)
-        head.updateDOM()
-      }
-    })
-
-    return () => {
-      watchEffect(() => {
-        if (!slots.default) return
-        if (obj) {
-          head.removeHeadObjs(obj)
-        }
-        obj = ref(vnodesToHeadObj(slots.default()))
-        head.addHeadObjs(obj)
-        if (IS_BROWSER) {
-          head.updateDOM()
-        }
-      })
-      return null
-    }
-  },
-})
+export * from './components'

--- a/src/stringify-attrs.ts
+++ b/src/stringify-attrs.ts
@@ -9,9 +9,9 @@
 export const stringifyAttrName = (str: string) =>
   str
     // replace special characters
-    .replace(/[\s"'><\/=]/g, "")
+    .replace(/[\s"'><\/=]/g, '')
     // replace noncharacters (except for - and _)
-    .replace(/[^a-zA-Z0-9_-]/g, "")
+    .replace(/[^a-zA-Z0-9_-]/g, '')
 /**
  * Double-quoted attribute value must not contain any literal U+0022 QUOTATION MARK characters ("). Including
  * < and > will cause HTML to be invalid.
@@ -19,28 +19,25 @@ export const stringifyAttrName = (str: string) =>
  * @see https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
  */
 export const stringifyAttrValue = (str: string) =>
-  str.replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+  str.replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
 
 export const stringifyAttrs = (attributes: Record<string, any>) => {
   const handledAttributes = []
 
-  for (let [key, value] of Object.entries(attributes)) {
-    if (key === "children" || key === "key") {
+  for (const [key, value] of Object.entries(attributes)) {
+    if (key === 'children' || key === 'key')
       continue
-    }
 
-    if (value === false || value == null) {
+    if (value === false || value == null)
       continue
-    }
 
     let attribute = stringifyAttrName(key)
 
-    if (value !== true) {
+    if (value !== true)
       attribute += `="${stringifyAttrValue(String(value))}"`
-    }
 
     handledAttributes.push(attribute)
   }
 
-  return handledAttributes.length > 0 ? " " + handledAttributes.join(" ") : ""
+  return handledAttributes.length > 0 ? ` ${handledAttributes.join(' ')}` : ''
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { Head as PlainHead, ReactiveHead } from "@zhead/schema-vue"
+import type { Head as PlainHead, ReactiveHead } from '@zhead/schema-vue'
 
 export interface HandlesDuplicates {
   /**
@@ -58,17 +58,17 @@ interface HeadAugmentations {
   }
   link: HasRenderPriority & RendersToBody & { key?: never; children?: never }
   meta: HasRenderPriority &
-    HandlesDuplicates & { children?: never; body?: never }
+  HandlesDuplicates & { children?: never; body?: never }
   style: HasRenderPriority &
-    RendersToBody &
-    RendersInnerContent & { key?: never; vmid?: never; hid?: never }
+  RendersToBody &
+  RendersInnerContent & { key?: never; vmid?: never; hid?: never }
   script: HasRenderPriority &
-    RendersToBody &
-    RendersInnerContent &
-    HandlesDuplicates
+  RendersToBody &
+  RendersInnerContent &
+  HandlesDuplicates
   noscript: HasRenderPriority &
-    RendersToBody &
-    RendersInnerContent & { key?: never; vmid?: never; hid?: never }
+  RendersToBody &
+  RendersInnerContent & { key?: never; vmid?: never; hid?: never }
   htmlAttrs: {
     renderPriority?: never
     key?: never
@@ -89,4 +89,4 @@ interface HeadAugmentations {
 
 export type HeadObjectPlain = PlainHead<HeadAugmentations>
 export type HeadObject = ReactiveHead<HeadAugmentations>
-export type TagKeys = keyof Omit<HeadObjectPlain, "titleTemplate">
+export type TagKeys = keyof Omit<HeadObjectPlain, 'titleTemplate'>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,12 +1,39 @@
+export const sortTags = (aTag: HeadTag, bTag: HeadTag) => {
+  const tagWeight = (tag: HeadTag) => {
+    if (tag.props.renderPriority)
+      return tag.props.renderPriority
+
+    switch (tag.tag) {
+      // This element must come before other elements with attribute values of URLs
+      case 'base':
+        return -1
+      case 'meta':
+        // charset must come early in case there's non-utf8 characters in the HTML document
+        if (tag.props.charset)
+          return -2
+
+        // CSP needs to be as it effects the loading of assets
+        if (tag.props['http-equiv'] === 'content-security-policy')
+          return 0
+
+        return 10
+      default:
+        // arbitrary safe number that can go up and down without conflicting
+        return 10
+    }
+  }
+  return tagWeight(aTag) - tagWeight(bTag)
+}
+
 // Shamelessly taken from Next.js
 export function isEqualNode(oldTag: Element, newTag: Element) {
   if (oldTag instanceof HTMLElement && newTag instanceof HTMLElement) {
-    const nonce = newTag.getAttribute("nonce")
+    const nonce = newTag.getAttribute('nonce')
     // Only strip the nonce if `oldTag` has had it stripped. An element's nonce attribute will not
     // be stripped if there is no content security policy response header that includes a nonce.
-    if (nonce && !oldTag.getAttribute("nonce")) {
+    if (nonce && !oldTag.getAttribute('nonce')) {
       const cloneTag = newTag.cloneNode(true) as typeof newTag
-      cloneTag.setAttribute("nonce", "")
+      cloneTag.setAttribute('nonce', '')
       cloneTag.nonce = nonce
       return nonce === oldTag.nonce && oldTag.isEqualNode(cloneTag)
     }

--- a/tests/dedupe.test.ts
+++ b/tests/dedupe.test.ts
@@ -1,19 +1,19 @@
-import { computed } from "vue"
-import { createHead, renderHeadToString } from "../src"
+import { computed } from 'vue'
+import { createHead, renderHeadToString } from '../src'
 
-describe("dedupe", () => {
-  it("dedupes desc", async () => {
+describe('dedupe', () => {
+  it('dedupes desc', async () => {
     const head = createHead()
     head.addHeadObjs(
       computed(() => ({
         meta: [
           {
-            name: "something-else",
-            content: "test",
+            name: 'something-else',
+            content: 'test',
           },
           {
-            name: "description",
-            content: "desc",
+            name: 'description',
+            content: 'desc',
           },
         ],
       })),
@@ -22,8 +22,8 @@ describe("dedupe", () => {
       computed(() => ({
         meta: [
           {
-            name: "description",
-            content: "desc 2",
+            name: 'description',
+            content: 'desc 2',
           },
         ],
       })),
@@ -32,42 +32,42 @@ describe("dedupe", () => {
     expect(
       headTags.includes('<meta name="description" content="desc 2">'),
     ).toBeTruthy()
-    expect(headTags.split("description").length === 2).toBeTruthy()
+    expect(headTags.split('description').length === 2).toBeTruthy()
   })
 
-  it("dedupes key", async () => {
+  it('dedupes key', async () => {
     const head = createHead()
     head.addHeadObjs(
       computed(() => ({
         meta: [
           {
-            myCustomMeta: "first",
-            key: "custom",
+            myCustomMeta: 'first',
+            key: 'custom',
           },
           {
-            myCustomMeta: "second",
-            key: "custom",
+            myCustomMeta: 'second',
+            key: 'custom',
           },
         ],
       })),
     )
     const { headTags } = renderHeadToString(head)
     expect(headTags.startsWith('<meta myCustomMeta="second">')).toBeTruthy()
-    expect(headTags.split("myCustomMeta").length === 2).toBeTruthy()
+    expect(headTags.split('myCustomMeta').length === 2).toBeTruthy()
   })
 
-  test("dedupes canonical", async () => {
+  test('dedupes canonical', async () => {
     const head = createHead()
     head.addHeadObjs(
       computed(() => ({
         link: [
           {
-            rel: "canonical",
-            href: "https://website.com",
+            rel: 'canonical',
+            href: 'https://website.com',
           },
           {
-            rel: "canonical",
-            href: "https://website.com/new",
+            rel: 'canonical',
+            href: 'https://website.com/new',
           },
         ],
       })),
@@ -78,19 +78,19 @@ describe("dedupe", () => {
         '<link rel="canonical" href="https://website.com/new">',
       ),
     ).toBeTruthy()
-    expect(headTags.split("canonical").length === 2).toBeTruthy()
+    expect(headTags.split('canonical').length === 2).toBeTruthy()
   })
 
-  test("dedupes charset", async () => {
+  test('dedupes charset', async () => {
     const head = createHead()
     head.addHeadObjs(
       computed(() => ({
         meta: [
           {
-            charset: "utf-8-overridden",
+            charset: 'utf-8-overridden',
           },
           {
-            charset: "utf-8-two",
+            charset: 'utf-8-two',
           },
         ],
       })),
@@ -99,46 +99,46 @@ describe("dedupe", () => {
       computed(() => ({
         meta: [
           {
-            charset: "utf-8",
+            charset: 'utf-8',
           },
         ],
       })),
     )
     const { headTags } = renderHeadToString(head)
     expect(headTags.startsWith('<meta charset="utf-8">')).toBeTruthy()
-    expect(headTags.split("charset").length === 2).toBeTruthy()
+    expect(headTags.split('charset').length === 2).toBeTruthy()
   })
 
-  test("dedupes base", async () => {
+  test('dedupes base', async () => {
     const head = createHead()
     head.addHeadObjs(
       computed(() => ({
         base: {
-          href: "/old",
-          target: "_blank",
+          href: '/old',
+          target: '_blank',
         },
       })),
     )
     head.addHeadObjs(
       computed(() => ({
         base: {
-          href: "/",
+          href: '/',
         },
       })),
     )
     const { headTags } = renderHeadToString(head)
-    expect(headTags.split("base").length === 2).toBeTruthy()
+    expect(headTags.split('base').length === 2).toBeTruthy()
     expect(headTags.startsWith('<base href="/">')).toBeTruthy()
   })
 
-  test("dedupes http-equiv", async () => {
+  test('dedupes http-equiv', async () => {
     const head = createHead()
     head.addHeadObjs(
       computed(() => ({
         meta: [
           {
-            "http-equiv": "content-security-policy",
-            content: "default-src https",
+            'http-equiv': 'content-security-policy',
+            'content': 'default-src https',
           },
         ],
       })),
@@ -147,24 +147,24 @@ describe("dedupe", () => {
       computed(() => ({
         meta: [
           {
-            "http-equiv": "content-security-policy",
-            content:
-              "default-src https: 'unsafe-eval' 'unsafe-inline'; object-src 'none'",
+            'http-equiv': 'content-security-policy',
+            'content':
+              'default-src https: \'unsafe-eval\' \'unsafe-inline\'; object-src \'none\'',
           },
         ],
       })),
     )
     const { headTags } = renderHeadToString(head)
-    expect(headTags.split("http-equiv").length === 2).toBeTruthy()
+    expect(headTags.split('http-equiv').length === 2).toBeTruthy()
   })
 
-  test("issue #104", async () => {
+  test('issue #104', async () => {
     const head = createHead()
     head.addHeadObjs(
       computed(() => ({
         link: [
-          { rel: "icon", href: "/favicon.ico" }, // <-- this and,
-          { rel: "canonical", href: "https://mydomain.me" }, // <-- this. Please reverse the order to be sure.
+          { rel: 'icon', href: '/favicon.ico' }, // <-- this and,
+          { rel: 'canonical', href: 'https://mydomain.me' }, // <-- this. Please reverse the order to be sure.
         ],
       })),
     )
@@ -174,18 +174,18 @@ describe("dedupe", () => {
     )
   })
 
-  test("doesn't dedupe over tag types", async () => {
+  test('doesn\'t dedupe over tag types', async () => {
     const head = createHead()
     head.addHeadObjs(
       computed(() => ({
         meta: [
           {
-            key: "icon",
-            name: "description",
-            content: "test",
+            key: 'icon',
+            name: 'description',
+            content: 'test',
           },
         ],
-        link: [{ rel: "icon", href: "/favicon.ico", key: "icon" }],
+        link: [{ rel: 'icon', href: '/favicon.ico', key: 'icon' }],
       })),
     )
     const { headTags } = renderHeadToString(head)
@@ -194,15 +194,15 @@ describe("dedupe", () => {
     )
   })
 
-  test("dedupes legacy", async () => {
+  test('dedupes legacy', async () => {
     const head = createHead()
     head.addHeadObjs(
       computed(() => ({
         meta: [
           {
-            "unknown-key": "description",
-            vmid: "desc-1",
-            content: "test",
+            'unknown-key': 'description',
+            'vmid': 'desc-1',
+            'content': 'test',
           },
         ],
       })),
@@ -211,9 +211,9 @@ describe("dedupe", () => {
       computed(() => ({
         meta: [
           {
-            "unknown-key": "description",
-            vmid: "desc-2",
-            content: "test 2",
+            'unknown-key': 'description',
+            'vmid': 'desc-2',
+            'content': 'test 2',
           },
         ],
       })),

--- a/tests/e2e/nuxt3/nuxt.test.ts
+++ b/tests/e2e/nuxt3/nuxt.test.ts
@@ -1,20 +1,20 @@
-import { fileURLToPath } from "node:url"
-import { $fetch, setup } from "@nuxt/test-utils"
-import { expectNoClientErrors } from "./utils"
-import { load } from "cheerio"
+import { fileURLToPath } from 'node:url'
+import { $fetch, setup } from '@nuxt/test-utils'
+import { load } from 'cheerio'
+import { expectNoClientErrors } from './utils'
 
 await setup({
-  rootDir: fileURLToPath(new URL("../../../examples/nuxt3", import.meta.url)),
+  rootDir: fileURLToPath(new URL('../../../examples/nuxt3', import.meta.url)),
   server: true,
   browser: true,
 })
 
-describe("e2e: nuxt 3", () => {
-  it("basic", async () => {
-    const html = await $fetch("/")
+describe('e2e: nuxt 3', () => {
+  it('basic', async () => {
+    const html = await $fetch('/')
     const $ = load(html as string)
-    expect($("title").text()).equals("Home | Nuxt | Title Site")
-    expect($('meta[name="head:count"]').attr("content")).toMatch("2")
-    await expectNoClientErrors("/")
+    expect($('title').text()).equals('Home | Nuxt | Title Site')
+    expect($('meta[name="head:count"]').attr('content')).toMatch('2')
+    await expectNoClientErrors('/')
   })
 })

--- a/tests/e2e/nuxt3/utils.ts
+++ b/tests/e2e/nuxt3/utils.ts
@@ -1,26 +1,28 @@
-import { getBrowser, url, useTestContext } from "@nuxt/test-utils"
-import { expect } from "vitest"
+import { getBrowser, url, useTestContext } from '@nuxt/test-utils'
+import { expect } from 'vitest'
 
-export async function renderPage(path = "/") {
+export async function renderPage(path = '/') {
   const ctx = useTestContext()
-  if (!ctx.options.browser) return
+  if (!ctx.options.browser)
+    return
 
   const browser = await getBrowser()
   const page = await browser.newPage({})
   const pageErrors: any = []
   const consoleLogs: any = []
 
-  page.on("console", (message: any) => {
+  page.on('console', (message: any) => {
     consoleLogs.push({
       type: message.type(),
       text: message.text(),
     })
   })
-  page.on("pageerror", (err: any) => {
+  page.on('pageerror', (err: any) => {
     pageErrors.push(err)
   })
 
-  if (path) await page.goto(url(path), { waitUntil: "networkidle" })
+  if (path)
+    await page.goto(url(path), { waitUntil: 'networkidle' })
 
   return <any>{
     page,
@@ -31,13 +33,14 @@ export async function renderPage(path = "/") {
 
 export async function expectNoClientErrors(path: string) {
   const ctx = useTestContext()
-  if (!ctx.options.browser) return
+  if (!ctx.options.browser)
+    return
 
   const { pageErrors, consoleLogs } = await renderPage(path)
 
-  const consoleLogErrors = consoleLogs.filter((i: any) => i.type === "error")
+  const consoleLogErrors = consoleLogs.filter((i: any) => i.type === 'error')
   const consoleLogWarnings = consoleLogs.filter(
-    (i: any) => i.type === "warning",
+    (i: any) => i.type === 'warning',
   )
 
   expect(pageErrors).toEqual([])

--- a/tests/e2e/vite-ssr/utils.ts
+++ b/tests/e2e/vite-ssr/utils.ts
@@ -1,37 +1,38 @@
-import { getRandomPort, waitForPort } from "get-port-please"
-import { execa } from "execa"
-import { fileURLToPath } from "node:url"
-import { resolvePath } from "mlly"
-import { resolve } from "pathe"
+import { fileURLToPath } from 'node:url'
+import { getRandomPort, waitForPort } from 'get-port-please'
+import { execa } from 'execa'
+import { resolvePath } from 'mlly'
+import { resolve } from 'pathe'
 
 const FixturePath = fileURLToPath(
-  new URL("../../../examples/vite-ssr", import.meta.url),
+  new URL('../../../examples/vite-ssr', import.meta.url),
 )
 
 export async function startServer() {
   const port = await getRandomPort()
 
-  const vite = resolve(await resolvePath("vite"), "../../../bin/vite.js")
-  const serverProcess = execa(vite, [".", "--port", port.toString()], {
+  const vite = resolve(await resolvePath('vite'), '../../../bin/vite.js')
+  const serverProcess = execa(vite, ['.', '--port', port.toString()], {
     cwd: FixturePath,
-    stdio: "inherit",
+    stdio: 'inherit',
     env: {
       ...process.env,
       PORT: String(port),
-      NODE_ENV: "development",
+      NODE_ENV: 'development',
     },
   })
   await waitForPort(port, { retries: 32 })
   for (let i = 0; i < 50; i++) {
-    await new Promise((resolve) => setTimeout(resolve, 100))
+    await new Promise(resolve => setTimeout(resolve, 100))
     try {
-      await $fetch("/")
-    } catch {}
+      await $fetch('/')
+    }
+    catch {}
   }
   return { serverProcess, url: `http://localhost:${port}` }
 }
 
 export async function createBrowser() {
-  const playwright = await import("playwright")
+  const playwright = await import('playwright')
   return await playwright.chromium.launch()
 }

--- a/tests/e2e/vite-ssr/vite-ssr.test.ts
+++ b/tests/e2e/vite-ssr/vite-ssr.test.ts
@@ -1,9 +1,9 @@
-import { HeadClient } from "../../../src"
-import { createBrowser, startServer } from "./utils"
-import { ExecaChildProcess } from "execa"
-import { Browser } from "playwright"
+import type { ExecaChildProcess } from 'execa'
+import type { Browser } from 'playwright'
+import type { HeadClient } from '../../../src'
+import { createBrowser, startServer } from './utils'
 
-describe("e2e: vite ssr", async () => {
+describe('e2e: vite ssr', async () => {
   let serverProcess: ExecaChildProcess
   let browser: Browser
   let url: string
@@ -16,15 +16,14 @@ describe("e2e: vite ssr", async () => {
   }, 60000)
 
   afterAll(async () => {
-    if (serverProcess) {
+    if (serverProcess)
       serverProcess.kill()
-    }
   })
 
-  test("browser", async () => {
+  test('browser', async () => {
     const page = await browser.newPage()
 
-    await page.goto(url, { waitUntil: "networkidle" })
+    await page.goto(url, { waitUntil: 'networkidle' })
     const headHTML = await page.evaluate(() => document.head.innerHTML)
 
     expect(headHTML).toMatchInlineSnapshot(`
@@ -38,41 +37,41 @@ describe("e2e: vite ssr", async () => {
         <meta name=\\"global-meta\\" content=\\"some global meta tag\\"><base href=\\"/\\"><meta name=\\"custom-priority\\" content=\\"of 1\\"><meta name=\\"description\\" content=\\"desc 2\\"><meta property=\\"og:locale:alternate\\" content=\\"fr\\"><meta property=\\"og:locale:alternate\\" content=\\"zh\\"><style>body {background: salmon}</style><noscript>This app requires javascript to work</noscript><script>console.log(\\"a\\")</script><link href=\\"/foo\\" rel=\\"stylesheet\\"><meta name=\\"head:count\\" content=\\"10\\">"
     `)
 
-    await page.click("button.counter")
-    expect(await page.title()).equals("count: 1 | @vueuse/head")
+    await page.click('button.counter')
+    expect(await page.title()).equals('count: 1 | @vueuse/head')
 
-    await page.click("button.change-home-title")
-    expect(await page.title()).equals("count: 1 | @vueuse/head")
+    await page.click('button.change-home-title')
+    expect(await page.title()).equals('count: 1 | @vueuse/head')
 
     await page.click('a[href="/about"]')
-    expect(await page.title()).equals("About | About Template")
+    expect(await page.title()).equals('About | About Template')
   })
 
-  test("<Head>: basic", async () => {
+  test('<Head>: basic', async () => {
     const page = await browser.newPage()
-    await page.goto(`${url}/contact`, { waitUntil: "networkidle" })
+    await page.goto(`${url}/contact`, { waitUntil: 'networkidle' })
     const getHeadTags = async () => {
       const head: HeadClient = await page.evaluate(() => {
-        // @ts-expect-error
+        // @ts-expect-error untyped
         return window.head
       })
       return head.headTags
     }
     expect(
-      (await getHeadTags()).find((t) => t.tag === "title")!.props.children,
+      (await getHeadTags()).find(t => t.tag === 'title')!.props.children,
     ).toMatchInlineSnapshot('"0 | @vueuse/head"')
-    await page.click("button")
+    await page.click('button')
     expect(
-      (await getHeadTags()).find((t) => t.tag === "title")!.props.children,
+      (await getHeadTags()).find(t => t.tag === 'title')!.props.children,
     ).toMatchInlineSnapshot('"1 | @vueuse/head"')
   })
 
-  test("body script", async () => {
+  test('body script', async () => {
     const page = await browser.newPage()
-    await page.goto(url, { waitUntil: "networkidle" })
+    await page.goto(url, { waitUntil: 'networkidle' })
 
-    const script = await page.$("[data-meta-body]")
+    const script = await page.$('[data-meta-body]')
     const scriptHtml = await script.innerHTML()
-    expect(scriptHtml).equals(`console.log('hi')`)
+    expect(scriptHtml).equals('console.log(\'hi\')')
   })
 })

--- a/tests/encoding.test.ts
+++ b/tests/encoding.test.ts
@@ -1,15 +1,15 @@
-import { computed } from "vue"
-import { createHead, renderHeadToString } from "../src"
+import { computed } from 'vue'
+import { createHead, renderHeadToString } from '../src'
 
-describe("encoding", () => {
-  it("jailbreak", async () => {
+describe('encoding', () => {
+  it('jailbreak', async () => {
     const head = createHead()
     head.addHeadObjs(
       computed(() => ({
         meta: [
           {
-            ['> console.alert("test")']:
-              "<style>body { background: red; }</style>",
+            '> console.alert("test")':
+              '<style>body { background: red; }</style>',
           },
         ],
       })),
@@ -21,20 +21,20 @@ describe("encoding", () => {
     )
   })
 
-  it("google maps", async () => {
+  it('google maps', async () => {
     const head = createHead()
     head.addHeadObjs(
       // @ts-expect-error computed issue
       computed(() => ({
         script: [
           {
-            src: "https://polyfill.io/v3/polyfill.min.js?features=default",
+            src: 'https://polyfill.io/v3/polyfill.min.js?features=default',
           },
           {
-            src: "https://maps.googleapis.com/maps/api/js?key=AIzaSyB41DRUbKWJHPxaFjMAwdrzWzbVKartNGg&callback=initMap&v=weekly",
-            ["data-key"]: "AIzaSyD9hQ0Z7Y9XQX8Zjwq7Q9Z2YQ9Z2YQ9Z2Y",
-            defer: true,
-            body: true,
+            'src': 'https://maps.googleapis.com/maps/api/js?key=AIzaSyB41DRUbKWJHPxaFjMAwdrzWzbVKartNGg&callback=initMap&v=weekly',
+            'data-key': 'AIzaSyD9hQ0Z7Y9XQX8Zjwq7Q9Z2YQ9Z2YQ9Z2Y',
+            'defer': true,
+            'body': true,
           },
         ],
       })),
@@ -51,7 +51,7 @@ describe("encoding", () => {
   })
 
   // Note: This should be fixed in a separate PR, possibly don't allow scripts without using useHeadRaw
-  it("xss", async () => {
+  it('xss', async () => {
     const externalApiHeadData = {
       script: [
         {

--- a/tests/priority.test.ts
+++ b/tests/priority.test.ts
@@ -1,24 +1,24 @@
-import { computed } from "vue"
-import { createHead, renderHeadToString } from "../src"
+import { computed } from 'vue'
+import { createHead, renderHeadToString } from '../src'
 
-describe("tag priority", () => {
-  test("charset first", async () => {
+describe('tag priority', () => {
+  test('charset first', async () => {
     const head = createHead()
     head.addHeadObjs(
       computed(() => ({
         script: [
           {
-            src: "/my-important-script.js",
+            src: '/my-important-script.js',
           },
         ],
         meta: [
           {
-            name: "something-else",
-            content: "test",
+            name: 'something-else',
+            content: 'test',
           },
           {
-            name: "description",
-            content: "desc",
+            name: 'description',
+            content: 'desc',
           },
         ],
       })),
@@ -27,7 +27,7 @@ describe("tag priority", () => {
       computed(() => ({
         meta: [
           {
-            charset: "utf-8",
+            charset: 'utf-8',
           },
         ],
       })),
@@ -36,23 +36,23 @@ describe("tag priority", () => {
     expect(headTags.startsWith('<meta charset="utf-8">')).toBeTruthy()
   })
 
-  test("base early", async () => {
+  test('base early', async () => {
     const head = createHead()
     head.addHeadObjs(
       computed(() => ({
         script: [
           {
-            src: "/my-important-script.js",
+            src: '/my-important-script.js',
           },
         ],
         meta: [
           {
-            name: "something-else",
-            content: "test",
+            name: 'something-else',
+            content: 'test',
           },
           {
-            name: "description",
-            content: "desc",
+            name: 'description',
+            content: 'desc',
           },
         ],
       })),
@@ -61,11 +61,11 @@ describe("tag priority", () => {
       computed(() => ({
         meta: [
           {
-            charset: "utf-8",
+            charset: 'utf-8',
           },
         ],
         base: {
-          href: "/base",
+          href: '/base',
         },
       })),
     )
@@ -75,23 +75,23 @@ describe("tag priority", () => {
     ).toBeTruthy()
   })
 
-  test("CSP early", async () => {
+  test('CSP early', async () => {
     const head = createHead()
     head.addHeadObjs(
       computed(() => ({
         script: [
           {
-            src: "/my-important-script.js",
+            src: '/my-important-script.js',
           },
         ],
         meta: [
           {
-            name: "something-else",
-            content: "test",
+            name: 'something-else',
+            content: 'test',
           },
           {
-            name: "description",
-            content: "desc",
+            name: 'description',
+            content: 'desc',
           },
         ],
       })),
@@ -100,8 +100,8 @@ describe("tag priority", () => {
       computed(() => ({
         meta: [
           {
-            "http-equiv": "content-security-policy",
-            content: "test",
+            'http-equiv': 'content-security-policy',
+            'content': 'test',
           },
         ],
       })),
@@ -114,13 +114,13 @@ describe("tag priority", () => {
     ).toBeTruthy()
   })
 
-  test("manual priority", async () => {
+  test('manual priority', async () => {
     const head = createHead()
     head.addHeadObjs(
       computed(() => ({
         script: [
           {
-            src: "/not-important-script.js",
+            src: '/not-important-script.js',
           },
         ],
       })),
@@ -129,7 +129,7 @@ describe("tag priority", () => {
       computed(() => ({
         script: [
           {
-            src: "/very-important-script.js",
+            src: '/very-important-script.js',
             renderPriority: 1,
           },
         ],

--- a/tests/reactivity-types.test.ts
+++ b/tests/reactivity-types.test.ts
@@ -1,58 +1,58 @@
-import { computed, createSSRApp, ref } from "vue"
-import { renderToString } from "@vue/server-renderer"
-import { createHead, renderHeadToString, useHead } from "../src"
-import { HeadObject, HeadObjectPlain } from "../src/types"
-import { ssrRenderHeadToString } from "./shared/utils"
+import { computed, createSSRApp, ref } from 'vue'
+import { renderToString } from '@vue/server-renderer'
+import { createHead, renderHeadToString, useHead } from '../src'
+import type { HeadObject, HeadObjectPlain } from '../src/types'
+import { ssrRenderHeadToString } from './shared/utils'
 
-describe("reactivity", () => {
-  test("basic", async () => {
-    const titleTemplate = ref("%s - My site")
+describe('reactivity', () => {
+  test('basic', async () => {
+    const titleTemplate = ref('%s - My site')
 
     const headResult = await ssrRenderHeadToString({
-      title: `hello`,
+      title: 'hello',
       titleTemplate,
       htmlAttrs: {
-        lang: ref("zh"),
+        lang: ref('zh'),
       },
       bodyAttrs: {
-        "data-some-body-attr": "some-value",
+        'data-some-body-attr': 'some-value',
       },
       meta: [
         {
-          name: "description",
-          content: ref("test"),
+          name: 'description',
+          content: ref('test'),
         },
         {
-          name: "description",
-          content: "desc 2",
+          name: 'description',
+          content: 'desc 2',
         },
         {
-          property: "og:locale:alternate",
-          content: "fr",
-          key: "fr",
+          property: 'og:locale:alternate',
+          content: 'fr',
+          key: 'fr',
         },
         {
-          property: "og:locale:alternate",
-          content: "zh",
-          key: "zh",
+          property: 'og:locale:alternate',
+          content: 'zh',
+          key: 'zh',
         },
       ],
       link: [
         {
-          as: "style",
-          href: "/style.css",
+          as: 'style',
+          href: '/style.css',
         },
       ],
       style: [
         {
-          children: "* { color: red }",
+          children: '* { color: red }',
           body: true,
         },
       ],
       script: [
         {
-          key: "foo-script",
-          src: "foo.js",
+          key: 'foo-script',
+          src: 'foo.js',
         },
       ],
     })
@@ -65,14 +65,14 @@ describe("reactivity", () => {
         "htmlAttrs": " lang=\\"zh\\" data-head-attrs=\\"lang\\"",
       }
     `)
-    expect(headResult.htmlAttrs).toEqual(` lang="zh" data-head-attrs="lang"`)
+    expect(headResult.htmlAttrs).toEqual(' lang="zh" data-head-attrs="lang"')
   })
 
-  test("computed", async () => {
+  test('computed', async () => {
     const head = createHead()
     const app = createSSRApp({
       setup() {
-        const title = ref("")
+        const title = ref('')
         useHead(
           computed<HeadObject>(() => {
             return {
@@ -80,8 +80,8 @@ describe("reactivity", () => {
             }
           }),
         )
-        title.value = "hello"
-        return () => "<div>hi</div>"
+        title.value = 'hello'
+        return () => '<div>hi</div>'
       },
     })
     app.use(head)
@@ -93,49 +93,49 @@ describe("reactivity", () => {
     )
   })
 
-  test("reactive", async () => {
+  test('reactive', async () => {
     const head = createHead()
     const app = createSSRApp({
       setup() {
-        const title = ref("")
-        const scripts = ref<Required<HeadObject>["script"]>([])
-        const urlMeta = computed<Required<HeadObjectPlain>["meta"][number]>(
+        const title = ref('')
+        const scripts = ref<Required<HeadObject>['script']>([])
+        const urlMeta = computed<Required<HeadObjectPlain>['meta'][number]>(
           () => {
             return {
-              property: "og:url",
-              content: "test",
+              property: 'og:url',
+              content: 'test',
             }
           },
         )
         useHead({
           title,
           htmlAttrs: {
-            lang: "test",
-            dir: "ltr",
+            lang: 'test',
+            dir: 'ltr',
           },
           meta: [
             {
-              name: "description",
-              content: computed(() => `${title.value} this is my description`),
-              "data-unknown-attr": "test",
+              'name': 'description',
+              'content': computed(() => `${title.value} this is my description`),
+              'data-unknown-attr': 'test',
             },
             {
-              property: "og:fake-prop",
-              content: "test",
+              property: 'og:fake-prop',
+              content: 'test',
             },
             {
-              name: "fake-name-prop",
-              content: "test",
+              name: 'fake-name-prop',
+              content: 'test',
             },
             urlMeta,
           ],
           script: scripts,
         })
         scripts.value.push({
-          src: "foo.js",
+          src: 'foo.js',
         })
-        title.value = "hello"
-        return () => "<div>hi</div>"
+        title.value = 'hello'
+        return () => '<div>hi</div>'
       },
     })
     app.use(head)
@@ -147,33 +147,33 @@ describe("reactivity", () => {
     )
   })
 
-  test("malformed", async () => {
+  test('malformed', async () => {
     const headResult = await ssrRenderHeadToString({
-      title: function () {
-        return "my title"
+      title() {
+        return 'my title'
       },
       meta: [
         {
           // @ts-expect-error number is not valid for name
-          name: 123,
-          "data-unknown-attr": "test",
+          'name': 123,
+          'data-unknown-attr': 'test',
           // @ts-expect-error meta cannot have children
-          children: "test",
+          'children': 'test',
         },
         {
-          name: "some-flag",
+          name: 'some-flag',
           // @ts-expect-error boolean is not valid for name
           content: true,
         },
         {
-          property: "og:fake-prop",
+          property: 'og:fake-prop',
           // @ts-expect-error arrays not allowed
-          content: ["test1", "test2"],
+          content: ['test1', 'test2'],
         },
       ],
     })
     expect(headResult.headTags).toMatchInlineSnapshot(`
-      "<title>function() {
+      "<title>title() {
               return \\"my title\\";
             }</title><meta name=\\"123\\" data-unknown-attr=\\"test\\"><meta name=\\"some-flag\\" content><meta property=\\"og:fake-prop\\" content=\\"test1,test2\\"><meta name=\\"head:count\\" content=\\"3\\">"
     `)

--- a/tests/shared/utils.ts
+++ b/tests/shared/utils.ts
@@ -1,13 +1,14 @@
-import { createHead, HeadObject, renderHeadToString, useHead } from "../../src"
-import { createSSRApp } from "vue"
-import { renderToString } from "@vue/server-renderer"
+import { createSSRApp } from 'vue'
+import { renderToString } from '@vue/server-renderer'
+import type { HeadObject } from '../../src'
+import { createHead, renderHeadToString, useHead } from '../../src'
 
 export async function ssrRenderHeadToString(input: HeadObject) {
   const head = createHead()
   const app = createSSRApp({
     setup() {
       useHead(input)
-      return () => "<div>hi</div>"
+      return () => '<div>hi</div>'
     },
   })
   app.use(head)

--- a/tests/vue-ssr.test.tsx
+++ b/tests/vue-ssr.test.tsx
@@ -1,38 +1,39 @@
-import { createSSRApp, ref, h } from "vue"
-import { renderToString } from "@vue/server-renderer"
-import { createHead, renderHeadToString, useHead, Head } from "../src"
-import { ssrRenderHeadToString } from "./shared/utils"
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { createSSRApp, h, ref } from 'vue'
+import { renderToString } from '@vue/server-renderer'
+import { Head, createHead, renderHeadToString, useHead } from '../src'
+import { ssrRenderHeadToString } from './shared/utils'
 
-describe("vue ssr", () => {
-  test("server", async () => {
+describe('vue ssr', () => {
+  test('server', async () => {
     const headResult = await ssrRenderHeadToString({
-      title: `hello`,
+      title: 'hello',
       htmlAttrs: {
-        lang: "zh",
+        lang: 'zh',
       },
       meta: [
         {
-          name: "description",
-          content: "desc",
+          name: 'description',
+          content: 'desc',
         },
         {
-          name: "description",
-          content: "desc 2",
+          name: 'description',
+          content: 'desc 2',
         },
         {
-          property: "og:locale:alternate",
-          content: "fr",
-          key: "fr",
+          property: 'og:locale:alternate',
+          content: 'fr',
+          key: 'fr',
         },
         {
-          property: "og:locale:alternate",
-          content: "zh",
-          key: "zh",
+          property: 'og:locale:alternate',
+          content: 'zh',
+          key: 'zh',
         },
       ],
       script: [
         {
-          src: "foo.js",
+          src: 'foo.js',
         },
       ],
     })
@@ -40,17 +41,17 @@ describe("vue ssr", () => {
     expect(headResult.headTags).toMatchInlineSnapshot(
       '"<title>hello</title><meta name=\\"description\\" content=\\"desc 2\\"><meta property=\\"og:locale:alternate\\" content=\\"fr\\"><meta property=\\"og:locale:alternate\\" content=\\"zh\\"><script src=\\"foo.js\\"></script><meta name=\\"head:count\\" content=\\"4\\">"',
     )
-    expect(headResult.htmlAttrs).toEqual(` lang="zh" data-head-attrs="lang"`)
+    expect(headResult.htmlAttrs).toEqual(' lang="zh" data-head-attrs="lang"')
   })
 
-  test("useHead: server async setup", async () => {
+  test('useHead: server async setup', async () => {
     const head = createHead()
     const app = createSSRApp({
       async setup() {
-        const title = ref(`initial title`)
+        const title = ref('initial title')
         useHead({ title })
-        await new Promise((resolve) => setTimeout(resolve, 200))
-        title.value = "new title"
+        await new Promise(resolve => setTimeout(resolve, 200))
+        title.value = 'new title'
         return () => <div>hi</div>
       },
     })
@@ -61,7 +62,7 @@ describe("vue ssr", () => {
     expect(headTags).match(/new title/)
   })
 
-  test("<Head>: link & meta with v-for", async () => {
+  test('<Head>: link & meta with v-for', async () => {
     const head = createHead()
     const app = createSSRApp({
       template: `<Head>
@@ -71,8 +72,8 @@ describe("vue ssr", () => {
       data() {
         return {
           metaList: [
-            { property: "test1", content: "test1" },
-            { property: "test2", content: "test2" },
+            { property: 'test1', content: 'test1' },
+            { property: 'test2', content: 'test2' },
           ],
         }
       },
@@ -86,13 +87,13 @@ describe("vue ssr", () => {
     )
   })
 
-  test("<Head>: server async setup", async () => {
+  test('<Head>: server async setup', async () => {
     const head = createHead()
     const app = createSSRApp({
       async setup() {
-        const title = ref(`initial title`)
-        await new Promise((resolve) => setTimeout(resolve, 200))
-        title.value = "new title"
+        const title = ref('initial title')
+        await new Promise(resolve => setTimeout(resolve, 200))
+        title.value = 'new title'
         return () => <Head>{() => <title>{title.value}</title>}</Head>
       },
     })
@@ -103,36 +104,36 @@ describe("vue ssr", () => {
     expect(headTags).match(/new title/)
   })
 
-  test("children", async () => {
+  test('children', async () => {
     const headResult = await ssrRenderHeadToString({
       script: [
         {
-          children: `console.log('hi')`,
+          children: 'console.log(\'hi\')',
         },
       ],
     })
 
     expect(headResult.headTags).equals(
-      `<script>console.log('hi')</script><meta name="head:count" content="1">`,
+      '<script>console.log(\'hi\')</script><meta name="head:count" content="1">',
     )
   })
 
-  test("script key", async () => {
+  test('script key', async () => {
     const headResult = await ssrRenderHeadToString({
       script: [
         {
-          key: "my-script",
-          children: `console.log('A')`,
+          key: 'my-script',
+          children: 'console.log(\'A\')',
         },
         {
-          key: "my-script",
-          children: `console.log('B')`,
+          key: 'my-script',
+          children: 'console.log(\'B\')',
         },
       ],
     })
 
     expect(headResult.headTags).equals(
-      `<script>console.log('B')</script><meta name="head:count" content="1">`,
+      '<script>console.log(\'B\')</script><meta name="head:count" content="1">',
     )
   })
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,8 @@
-/* eslint-disable spaced-comment */
 /// <reference types="vitest" />
 /// <reference types="vitest/globals" />
 
+import { resolve } from 'node:path'
 import { defineConfig } from 'vite'
-import {resolve} from "node:path";
 
 export default defineConfig({
   resolve: {


### PR DESCRIPTION
## Issue

While this migration to eslint seems perfunctory, there are a few reasons to do it:
- Consistency to vueuse ecosystem
- Better error catching, the template antfu created covers many more cases (incl Vue linting) than the current prettier implementation
- It's what I'm used to so will make maintenance easier (subjectively outputs easier code to read)

## Solution

Using https://github.com/antfu/eslint-config and running the lint.

This also includes a small refactor, moving the components to their own file. This was to overcome an eslint issue