### PR TITLE
feat: hook into resolved tags `hookTagsResolved`

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,13 +1,11 @@
-import type { Ref } from 'vue'
 import type { HandlesDuplicates, HasRenderPriority, RendersInnerContent, RendersToBody, TagKeys } from './schema'
 
 export * from './schema'
 
-export type MaybeRef<T> = T | Ref<T>
-
 export interface HeadAttrs { [k: string]: any }
 
-export type HookBeforeDomUpdate = ((tags: Record<string, HeadTag[]>) => void | boolean | Record<string, HeadTag[]>)[]
+export type HookBeforeDomUpdate = ((tags: Record<string, HeadTag[]>) => void | boolean)[]
+export type HookTagsResolved = ((tags: HeadTag[]) => void)[]
 
 export interface HeadTag {
   tag: TagKeys

--- a/tests/hook-tags-resolved.test.ts
+++ b/tests/hook-tags-resolved.test.ts
@@ -1,0 +1,76 @@
+import { computed } from 'vue'
+import { JSDOM } from 'jsdom'
+import { createHead } from '../src'
+
+describe('hook tags resolved', () => {
+  test('read tags', async () => {
+    const head = createHead()
+
+    const hookTags = new Promise((resolve) => {
+      head.hookTagsResolved.push((tags) => {
+        resolve(tags)
+      })
+    })
+
+    head.addHeadObjs(
+      computed(() => ({
+        title: 'test',
+      })),
+    )
+    const dom = new JSDOM(
+      '<!DOCTYPE html><html><head></head><body></body></html>',
+    )
+    head.updateDOM(dom.window.document)
+
+    const tags = await hookTags
+    expect(tags[0].tag).toEqual('title')
+    expect(tags[0].props.children).toEqual('test')
+    expect(tags).toMatchInlineSnapshot(`
+      [
+        {
+          "_position": 0,
+          "props": {
+            "children": "test",
+          },
+          "tag": "title",
+        },
+      ]
+    `)
+  })
+
+  test('write tags', async () => {
+    const head = createHead()
+
+    const hookTags = new Promise((resolve) => {
+      head.hookTagsResolved.push((tags) => {
+        for (const k in tags)
+          tags[k].props.extra = true
+
+        resolve(tags)
+      })
+    })
+
+    head.addHeadObjs(
+      computed(() => ({
+        title: 'test',
+      })),
+    )
+    const dom = new JSDOM(
+      '<!DOCTYPE html><html><head></head><body></body></html>',
+    )
+    head.updateDOM(dom.window.document)
+
+    const hooks = await hookTags
+    expect(hooks[0].props.extra).toBeTruthy()
+    expect(hooks[0]).toMatchInlineSnapshot(`
+      {
+        "_position": 0,
+        "props": {
+          "children": "test",
+          "extra": true,
+        },
+        "tag": "title",
+      }
+    `)
+  })
+})


### PR DESCRIPTION
## Issue

There is no way to modify the resolved head tags in both a SSR and client-side context.

## Solution

Add a simple hook to allow users to view and update tags as they are resolved.