### PR TITLE
feat(types): allow augmenting the types of head

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import {
   onBeforeUnmount,
   watchEffect,
 } from 'vue'
+import type { MergeHead } from '@zhead/schema'
 import {
   PROVIDE_KEY,
 } from './constants'
@@ -20,14 +21,14 @@ import { setAttrs, updateElements } from './dom'
 
 export * from './types'
 
-export interface HeadClient {
+export interface HeadClient<T extends MergeHead = {}> {
   install: (app: App) => void
 
   headTags: HeadTag[]
 
-  addHeadObjs: (objs: UseHeadInput) => void
+  addHeadObjs: (objs: UseHeadInput<T>) => void
 
-  removeHeadObjs: (objs: UseHeadInput) => void
+  removeHeadObjs: (objs: UseHeadInput<T>) => void
 
   updateDOM: (document?: Document) => void
 
@@ -50,8 +51,8 @@ export interface HeadClient {
  * Inject the head manager instance
  * Exported for advanced usage or library integration, you probably don't need this
  */
-export const injectHead = () => {
-  const head = inject<HeadClient>(PROVIDE_KEY)
+export const injectHead = <T extends MergeHead = {}>() => {
+  const head = inject<HeadClient<T>>(PROVIDE_KEY)
 
   if (!head)
     throw new Error('You may forget to apply app.use(head)')
@@ -133,8 +134,8 @@ const headObjToTags = (obj: HeadObjectPlain) => {
   return tags
 }
 
-export const createHead = (initHeadObject?: UseHeadInput) => {
-  let allHeadObjs: UseHeadInput[] = []
+export const createHead = <T extends MergeHead = {}>(initHeadObject?: UseHeadInput<T>) => {
+  let allHeadObjs: UseHeadInput<T>[] = []
   const previousTags = new Set<string>()
 
   const hookBeforeDomUpdate: HookBeforeDomUpdate = []
@@ -143,7 +144,7 @@ export const createHead = (initHeadObject?: UseHeadInput) => {
   if (initHeadObject)
     allHeadObjs.push(initHeadObject)
 
-  const head: HeadClient = {
+  const head: HeadClient<T> = {
     install(app) {
       app.config.globalProperties.$head = head
       app.provide(PROVIDE_KEY, head)
@@ -263,7 +264,7 @@ export const createHead = (initHeadObject?: UseHeadInput) => {
 
 const IS_BROWSER = typeof window !== 'undefined'
 
-export const useHead = (headObj: UseHeadInput) => {
+export const useHead = <T extends MergeHead = {}>(headObj: UseHeadInput<T>) => {
   const head = injectHead()
 
   head.addHeadObjs(headObj)

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -1,5 +1,6 @@
 import type { Head as PlainHead, ReactiveHead } from '@zhead/schema-vue'
 import type { MaybeComputedRef } from '@vueuse/shared'
+import type { MergeHead } from '@zhead/schema'
 
 export interface HandlesDuplicates {
   /**
@@ -52,7 +53,7 @@ export type Never<T> = {
   [P in keyof T]?: never
 }
 
-export interface HeadAugmentations {
+export interface VueUseHeadSchema extends MergeHead {
   base: Never<HandlesDuplicates & RendersInnerContent & HasRenderPriority & RendersToBody>
   link: HasRenderPriority & RendersToBody & Never<RendersInnerContent & HandlesDuplicates>
   meta: HasRenderPriority &
@@ -71,8 +72,8 @@ export interface HeadAugmentations {
   bodyAttrs: Never<HandlesDuplicates & RendersInnerContent & HasRenderPriority & RendersToBody>
 }
 
-export type HeadObjectPlain = PlainHead<HeadAugmentations>
-export type HeadObject = ReactiveHead<HeadAugmentations>
-export type TagKeys = keyof Omit<HeadObjectPlain, 'titleTemplate'>
-export type UseHeadInput = MaybeComputedRef<HeadObject>
+export type HeadObjectPlain<T extends MergeHead = {}> = PlainHead<T & VueUseHeadSchema>
+export type HeadObject<T extends MergeHead = {}> = ReactiveHead<T & VueUseHeadSchema>
+export type UseHeadInput<T extends MergeHead = {}> = MaybeComputedRef<HeadObject<T>>
 
+export type TagKeys = keyof Omit<HeadObjectPlain, 'titleTemplate'>

--- a/tests/custom-augmentations.test.ts
+++ b/tests/custom-augmentations.test.ts
@@ -1,0 +1,39 @@
+import { createSSRApp, ref } from 'vue'
+import { renderToString } from '@vue/server-renderer'
+import type { MergeHead } from '@zhead/schema'
+import { createHead, renderHeadToString, useHead } from '../src'
+
+describe('custom augmentation', () => {
+  test('link auto-completion', async () => {
+    interface CustomHead extends MergeHead {
+      link: {
+        href: 'link-one' | 'link/two' | 'link/number/three'
+      }
+    }
+
+    const head = createHead<CustomHead>()
+    const app = createSSRApp({
+      setup() {
+        const title = ref('')
+        useHead<CustomHead>({
+          title: title.value,
+          link: [
+            {
+              'data-test': () => 'test',
+              'href': 'link-one',
+            },
+          ],
+        })
+        title.value = 'hello'
+        return () => '<div>hi</div>'
+      },
+    })
+    app.use(head)
+    await renderToString(app)
+
+    const headResult = renderHeadToString(head)
+    expect(headResult.headTags).toMatchInlineSnapshot(
+      '"<title></title><link data-test=\\"test\\" href=\\"link-one\\"><meta name=\\"head:count\\" content=\\"1\\">"',
+    )
+  })
+})


### PR DESCRIPTION
## Issue

For some framework integrations, it's possible to augment the head types to provide a nicer DX. 

For example in Nuxt, we can augment the `link.href` attribute, adding auto-complete for all files in the public directory.

## Solution

Add a generic of an augmentation to the `useHead`, `createHead`, `injectHead` functions, zhead already provides a robust augmentation API. 

Integrations should wrap these functions with the generic to avoid users having to provide any custom augmentations explicitely. 