### PR TITLE
fix(ssr): encode `children`, `href` and `url` more appropriately

### DIFF
--- a/examples/nuxt3/pages/index.vue
+++ b/examples/nuxt3/pages/index.vue
@@ -9,6 +9,12 @@ const page = ref({
 
 useHead({
   title: computed(() => `${page.value.title} | Nuxt`),
+  script: [
+    // note: this is still XSS vulnerable
+    {
+      children: 'alert(2)',
+    },
+  ],
   meta: [
     {
       name: 'description',

--- a/examples/nuxt3/pages/index.vue
+++ b/examples/nuxt3/pages/index.vue
@@ -9,12 +9,12 @@ const page = ref({
 
 useHead({
   title: computed(() => `${page.value.title} | Nuxt`),
-  script: [
-    // note: this is still XSS vulnerable
-    {
-      children: 'alert(2)',
-    },
-  ],
+  // note: this is still XSS vulnerable
+  // script: [
+  // {
+  //   children: 'alert(2)',
+  // },
+  // ],
   meta: [
     {
       name: 'description',

--- a/src/ssr/stringify-attrs.ts
+++ b/src/ssr/stringify-attrs.ts
@@ -1,3 +1,33 @@
+export const escapeHtml = (s: string) =>
+  s.replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+
+export const escapeJS = (s: string) =>
+  s.replace(/["'\\\n\r\u2028\u2029]/g, (character) => {
+    // Escape all characters not included in SingleStringCharacters and
+    // DoubleStringCharacters on
+    // http://www.ecma-international.org/ecma-262/5.1/#sec-7.8.4
+    switch (character) {
+      case '"':
+      case '\'':
+      case '\\':
+        return `\\${character}`
+      // Four possible LineTerminator characters need to be escaped:
+      case '\n':
+        return '\\n'
+      case '\r':
+        return '\\r'
+      case '\u2028':
+        return '\\u2028'
+      case '\u2029':
+        return '\\u2029'
+    }
+    return character
+  })
+
 /**
  * Attribute names must consist of one or more characters other than controls, U+0020 SPACE, U+0022 ("), U+0027 ('),
  * U+003E (>), U+002F (/), U+003D (=), and noncharacters.
@@ -19,7 +49,7 @@ export const stringifyAttrName = (str: string) =>
  * @see https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
  */
 export const stringifyAttrValue = (str: string) =>
-  str.replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+  escapeJS(str.replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;'))
 
 export const stringifyAttrs = (attributes: Record<string, any>) => {
   const handledAttributes = []
@@ -33,8 +63,17 @@ export const stringifyAttrs = (attributes: Record<string, any>) => {
 
     let attribute = stringifyAttrName(key)
 
-    if (value !== true)
-      attribute += `="${stringifyAttrValue(String(value))}"`
+    if (value !== true) {
+      const val = String(value)
+      /*
+       * Link attributes should be URI encoded to prevent XSS.
+       * @see https://cheatsheetseries.owasp.org/cheatsheets/DOM_based_XSS_Prevention_Cheat_Sheet.html#rule-5-url-escape-then-javascript-escape-before-inserting-untrusted-data-into-url-attribute-subcontext-within-the-execution-context
+       */
+      if (attribute === 'href' || attribute === 'src')
+        attribute += `="${stringifyAttrValue(encodeURI(val))}"`
+      else
+        attribute += `="${stringifyAttrValue(val)}"`
+    }
 
     handledAttributes.push(attribute)
   }

--- a/tests/encoding.test.ts
+++ b/tests/encoding.test.ts
@@ -63,7 +63,7 @@ describe('encoding', () => {
     head.addHeadObjs(computed(() => externalApiHeadData))
     const { headTags } = renderHeadToString(head)
     expect(headTags).toMatchInlineSnapshot(
-      '"<script>console.alert(\\"xss\\")</script><meta name=\\"head:count\\" content=\\"1\\">"',
+      '"<script>console.alert(&quot;xss&quot;)</script><meta name=\\"head:count\\" content=\\"1\\">"',
     )
   })
 })

--- a/tests/vue-ssr.test.tsx
+++ b/tests/vue-ssr.test.tsx
@@ -113,8 +113,8 @@ describe('vue ssr', () => {
       ],
     })
 
-    expect(headResult.headTags).equals(
-      '<script>console.log(\'hi\')</script><meta name="head:count" content="1">',
+    expect(headResult.headTags).toMatchInlineSnapshot(
+      '"<script>console.log(&#39;hi&#39;)</script><meta name=\\"head:count\\" content=\\"1\\">"',
     )
   })
 
@@ -132,8 +132,8 @@ describe('vue ssr', () => {
       ],
     })
 
-    expect(headResult.headTags).equals(
-      '<script>console.log(\'B\')</script><meta name="head:count" content="1">',
+    expect(headResult.headTags).toMatchInlineSnapshot(
+      '"<script>console.log(&#39;B&#39;)</script><meta name=\\"head:count\\" content=\\"1\\">"',
     )
   })
 })


### PR DESCRIPTION
## Issue

The SSR context does not encode `children` as it is used client-side, as `textContent`.

Additionally, URL specific attributes should be URI encoded.

## Solution

Follow best practices https://cheatsheetseries.owasp.org/cheatsheets/XSS_Filter_Evasion_Cheat_Sheet.html 

Note that `children` on a script tag is still vulnerable as well as any of the event handlers' attributes. This will be fixed in a subsequent PR that introduces `useHeadRaw`.

