### PR TITLE
fix: warn script children usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ useHead({
 To render tags at the end of the `<body>`, set `body: true` in a HeadAttrs Object.
 
 ```ts
-useHead({
+useHeadRaw({
   script: [
     {
       children: `console.log('Hello world!')`,

--- a/examples/vite-ssr/app.tsx
+++ b/examples/vite-ssr/app.tsx
@@ -1,4 +1,4 @@
-import { computed, createSSRApp, defineComponent, ref } from 'vue'
+import { createSSRApp, defineComponent, ref } from 'vue'
 import {
   RouterLink,
   RouterView,
@@ -6,7 +6,7 @@ import {
   createRouter,
   createWebHistory,
 } from 'vue-router'
-import { createHead, useHead } from '../../src'
+import { createHead, useHead, useHeadRaw } from '../../src'
 import Contact from './Contact.vue'
 
 export const createApp = () => {
@@ -15,8 +15,10 @@ export const createApp = () => {
       const count = ref(0)
       useHead({
         title: (() => `count: ${count.value}`),
-        script: [{ children: 'console.log("a")', key: 'a' }],
         link: [{ href: '/foo', rel: 'stylesheet' }],
+      })
+      useHeadRaw({
+        script: [{ children: 'console.log("a")', key: 'a' }],
       })
       return () => (
         <button
@@ -67,6 +69,9 @@ export const createApp = () => {
             renderPriority: 1,
           },
         ],
+      })
+
+      useHeadRaw({
         script: [
           {
             children: 'console.log(\'hi\')',

--- a/examples/vite-ssr/pages/ssr/dedup.vue
+++ b/examples/vite-ssr/pages/ssr/dedup.vue
@@ -17,6 +17,9 @@ useHead({
       `,
     },
   ],
+})
+
+useHeadRaw({
   script: [
     {
       children: `

--- a/src/index.ts
+++ b/src/index.ts
@@ -209,11 +209,7 @@ export const createHead = <T extends MergeHead = {}>(initHeadObject?: UseHeadInp
       // ensure their original positions are kept
       const tags = deduped.sort((a, b) => a._position! - b._position!)
 
-      if (head.hookTagsResolved) {
-        for (const k in head.hookTagsResolved)
-          head.hookTagsResolved[k](tags)
-      }
-
+      head.hookTagsResolved.forEach(fn => fn(tags))
       return tags
     },
 
@@ -259,12 +255,9 @@ export const createHead = <T extends MergeHead = {}>(initHeadObject?: UseHeadInp
       }
       const doDomUpdate = () => {
         // allow integration to disable dom update and / or modify it
-        if (head.hookBeforeDomUpdate) {
-          for (const k in head.hookBeforeDomUpdate) {
-            const res = head.hookBeforeDomUpdate[k](domCtx.actualTags)
-            if (res === false)
-              return
-          }
+        for (const k in head.hookBeforeDomUpdate) {
+          if (head.hookBeforeDomUpdate[k](domCtx.actualTags) === false)
+            return
         }
         updateDOM({ domCtx, document, previousTags })
         domUpdateTick = null

--- a/src/ssr/index.ts
+++ b/src/ssr/index.ts
@@ -36,6 +36,12 @@ export const tagToString = (tag: HeadTag) => {
 
   // children is deprecated
   if (!innerContent && tag.props.children) {
+    if (tag.tag === 'script') {
+      if (tag._options?.raw)
+        console.warn('[@vueuse/head] Warning, you must use `innerHTML` with `useHeadRaw` instead of `children` for script content.', tag)
+      else
+        console.warn('[@vueuse/head] Warning, you must use `useHeadRaw` with `innerHTML` for script content. See https://github.com/vueuse/head/pull/118', tag)
+    }
     /*
      * DOM updates is using textContent which doesn't allow HTML or JS already, so SSR needs to match
      *

--- a/tests/shared/utils.ts
+++ b/tests/shared/utils.ts
@@ -1,13 +1,12 @@
 import { createSSRApp } from 'vue'
 import { renderToString } from '@vue/server-renderer'
-import type { UseHeadInput } from '../../src'
-import { createHead, renderHeadToString, useHead } from '../../src'
+import { createHead, renderHeadToString } from '../../src'
 
-export async function ssrRenderHeadToString(input: UseHeadInput) {
+export async function ssrRenderHeadToString(fn: () => void) {
   const head = createHead()
   const app = createSSRApp({
     setup() {
-      useHead(input)
+      fn()
       return () => '<div>hi</div>'
     },
   })

--- a/tests/vue-ssr.test.tsx
+++ b/tests/vue-ssr.test.tsx
@@ -1,12 +1,12 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { createSSRApp, h, ref } from 'vue'
 import { renderToString } from '@vue/server-renderer'
-import { Head, createHead, renderHeadToString, useHead } from '../src'
+import { Head, createHead, renderHeadToString, useHead, useHeadRaw } from '../src'
 import { ssrRenderHeadToString } from './shared/utils'
 
 describe('vue ssr', () => {
   test('server', async () => {
-    const headResult = await ssrRenderHeadToString({
+    const headResult = await ssrRenderHeadToString(() => useHead({
       title: 'hello',
       htmlAttrs: {
         lang: 'zh',
@@ -36,7 +36,7 @@ describe('vue ssr', () => {
           src: 'foo.js',
         },
       ],
-    })
+    }))
 
     expect(headResult.headTags).toMatchInlineSnapshot(
       '"<title>hello</title><meta name=\\"description\\" content=\\"desc 2\\"><meta property=\\"og:locale:alternate\\" content=\\"fr\\"><meta property=\\"og:locale:alternate\\" content=\\"zh\\"><script src=\\"foo.js\\"></script><meta name=\\"head:count\\" content=\\"4\\">"',
@@ -105,12 +105,14 @@ describe('vue ssr', () => {
   })
 
   test('children', async () => {
-    const headResult = await ssrRenderHeadToString({
-      script: [
-        {
-          children: 'console.log(\'hi\')',
-        },
-      ],
+    const headResult = await ssrRenderHeadToString(() => {
+      useHeadRaw({
+        script: [
+          {
+            children: 'console.log(\'hi\')',
+          },
+        ],
+      })
     })
 
     expect(headResult.headTags).toMatchInlineSnapshot(
@@ -119,7 +121,7 @@ describe('vue ssr', () => {
   })
 
   test('script key', async () => {
-    const headResult = await ssrRenderHeadToString({
+    const headResult = await ssrRenderHeadToString(() => useHeadRaw({
       script: [
         {
           key: 'my-script',
@@ -130,7 +132,7 @@ describe('vue ssr', () => {
           children: 'console.log(\'B\')',
         },
       ],
-    })
+    }))
 
     expect(headResult.headTags).toMatchInlineSnapshot(
       '"<script>console.log(&#39;B&#39;)</script><meta name=\\"head:count\\" content=\\"1\\">"',


### PR DESCRIPTION
## Issue

It might be confusing and hard to identify issues when migrating to the latest @vueuse/head with the XSS fixes.

## Solution

To help users with the migration to `useHeadRaw` when SSR, we show a warning message if they are not using the tag correctly.