### PR TITLE
fix(xss) drop non-raw `on` handles and `innerHTML`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -209,11 +209,7 @@ export const createHead = <T extends MergeHead = {}>(initHeadObject?: UseHeadInp
       // ensure their original positions are kept
       const tags = deduped.sort((a, b) => a._position! - b._position!)
 
-      if (head.hookTagsResolved) {
-        for (const k in head.hookTagsResolved)
-          head.hookTagsResolved[k](tags)
-      }
-
+      head.hookTagsResolved.forEach(fn => fn(tags))
       return tags
     },
 
@@ -259,12 +255,9 @@ export const createHead = <T extends MergeHead = {}>(initHeadObject?: UseHeadInp
       }
       const doDomUpdate = () => {
         // allow integration to disable dom update and / or modify it
-        if (head.hookBeforeDomUpdate) {
-          for (const k in head.hookBeforeDomUpdate) {
-            const res = head.hookBeforeDomUpdate[k](domCtx.actualTags)
-            if (res === false)
-              return
-          }
+        for (const k in head.hookBeforeDomUpdate) {
+          if (head.hookBeforeDomUpdate[k](domCtx.actualTags) === false)
+            return
         }
         updateDOM({ domCtx, document, previousTags })
         domUpdateTick = null

--- a/src/index.ts
+++ b/src/index.ts
@@ -203,7 +203,12 @@ export const createHead = <T extends MergeHead = {}>(initHeadObject?: UseHeadInp
                 delete tag.props[k]
               }
             }
+            if (tag.props.innerHTML) {
+              console.warn('[@vueuse/head] Warning, you must use `useHeadRaw` to use `innerHTML`', tag)
+              delete tag.props.innerHTML
+            }
           }
+
           // Remove tags with the same key
           const dedupeKey = tagDedupeKey(tag)
           if (dedupeKey)

--- a/src/index.ts
+++ b/src/index.ts
@@ -195,6 +195,15 @@ export const createHead = <T extends MergeHead = {}>(initHeadObject?: UseHeadInp
               tag.props.textContent,
             )
           }
+          // validate XSS vectors
+          if (!tag._options?.raw) {
+            for (const k in tag.props) {
+              if (k.startsWith('on')) {
+                console.warn('[@vueuse/head] Warning, you must use `useHeadRaw` to set event listeners. See https://github.com/vueuse/head/pull/118', tag)
+                delete tag.props[k]
+              }
+            }
+          }
           // Remove tags with the same key
           const dedupeKey = tagDedupeKey(tag)
           if (dedupeKey)
@@ -241,12 +250,8 @@ export const createHead = <T extends MergeHead = {}>(initHeadObject?: UseHeadInp
           domCtx.title = tag.props.textContent
           continue
         }
-        if (tag.tag === 'htmlAttrs') {
-          Object.assign(domCtx.htmlAttrs, tag.props)
-          continue
-        }
-        if (tag.tag === 'bodyAttrs') {
-          Object.assign(domCtx.bodyAttrs, tag.props)
+        if (tag.tag === 'htmlAttrs' || tag.tag === 'bodyAttrs') {
+          Object.assign(domCtx[tag.tag], tag.props)
           continue
         }
 

--- a/src/ssr/index.ts
+++ b/src/ssr/index.ts
@@ -25,6 +25,9 @@ export const tagToString = (tag: HeadTag) => {
 
   let innerContent = ''
 
+  if (tag._options?.raw && tag.props.innerHTML)
+    innerContent = tag.props.innerHTML
+
   if (!innerContent && tag.props.textContent)
     innerContent = escapeJS(escapeHtml(tag.props.textContent))
 

--- a/src/ssr/index.ts
+++ b/src/ssr/index.ts
@@ -66,10 +66,6 @@ export const renderHeadToString = (head: HeadClient): HTMLResult => {
     else if (tag.tag === 'htmlAttrs' || tag.tag === 'bodyAttrs') {
       for (const k in tag.props) {
         const keyName = stringifyAttrName(k)
-        if (!tag._options?.raw && keyName.startsWith('on')) {
-          console.warn('[@vueuse/head] Warning, you must use `useHeadRaw` to set event listeners. See https://github.com/vueuse/head/pull/118', keyName)
-          continue
-        }
         // always encode name to avoid html errors
         attrs[tag.tag][keyName] = tag._options?.raw ? tag.props[keyName] : tag.props[stringifyAttrValue(keyName)]
       }

--- a/src/ssr/index.ts
+++ b/src/ssr/index.ts
@@ -31,21 +31,13 @@ export const tagToString = (tag: HeadTag) => {
   if (!innerContent && tag.props.textContent)
     innerContent = escapeJS(escapeHtml(tag.props.textContent))
 
-  // children is deprecated
-  if (!innerContent && tag.props.children) {
-    if (tag.tag === 'script') {
-      if (tag._options?.raw)
-        console.warn('[@vueuse/head] Warning, you must use `innerHTML` with `useHeadRaw` instead of `children` for script content.', tag)
-      else
-        console.warn('[@vueuse/head] Warning, you must use `useHeadRaw` with `innerHTML` for script content. See https://github.com/vueuse/head/pull/118', tag)
-    }
+  if (!innerContent && tag.props.children)
     /*
      * DOM updates is using textContent which doesn't allow HTML or JS already, so SSR needs to match
      *
      * @see https://cheatsheetseries.owasp.org/cheatsheets/DOM_based_XSS_Prevention_Cheat_Sheet.html#rule-1-html-escape-then-javascript-escape-before-inserting-untrusted-data-into-html-subcontext-within-the-execution-context
      */
     innerContent = escapeJS(escapeHtml(tag.props.children))
-  }
 
   return `<${tag.tag}${attrs}${
     isBodyTag ? ` ${BODY_TAG_ATTR_NAME}="true"` : ''

--- a/src/ssr/index.ts
+++ b/src/ssr/index.ts
@@ -25,12 +25,6 @@ export const tagToString = (tag: HeadTag) => {
 
   let innerContent = ''
 
-  if (tag.props.innerHTML) {
-    if (tag._options?.raw)
-      innerContent = tag.props.innerHTML
-    else
-      console.warn('[@vueuse/head] Warning, you must use `useHeadRaw` to set innerHTML', tag.props.innerHTML)
-  }
   if (!innerContent && tag.props.textContent)
     innerContent = escapeJS(escapeHtml(tag.props.textContent))
 

--- a/src/ssr/stringify-attrs.ts
+++ b/src/ssr/stringify-attrs.ts
@@ -65,11 +65,6 @@ export const stringifyAttrs = (attributes: Record<string, any>, options: HeadEnt
 
     let attribute = stringifyAttrName(key)
 
-    if (!options.raw && attribute.startsWith('on')) {
-      console.warn('[@vueuse/head] Warning, you must use `useHeadRaw` to set event listeners. See https://github.com/vueuse/head/pull/118', attribute)
-      continue
-    }
-
     if (value !== true) {
       const val = String(value)
       if (options.raw) {

--- a/tests/encoding.test.ts
+++ b/tests/encoding.test.ts
@@ -16,13 +16,13 @@ describe('encoding', () => {
         }],
         noscript: [
           {
-            textContent: '<iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXXXXX" height="0" width="0" style="display:none;visibility:hidden"></iframe>',
+            innerHTML: '<iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXXXXX" height="0" width="0" style="display:none;visibility:hidden"></iframe>',
           },
         ],
       })),
     )
     const { htmlAttrs, headTags } = renderHeadToString(head)
-    expect(headTags).toMatchInlineSnapshot('"<script src=\\"javascript:console.log(\\\\\'xss\\\\\');\\"></script><noscript>&lt;iframe src=&quot;https://www.googletagmanager.com/ns.html?id=GTM-XXXXXXX&quot; height=&quot;0&quot; width=&quot;0&quot; style=&quot;display:none;visibility:hidden&quot;&gt;&lt;/iframe&gt;</noscript><meta name=\\"head:count\\" content=\\"2\\">"')
+    expect(headTags).toMatchInlineSnapshot('"<script src=\\"javascript:console.log(\\\\\'xss\\\\\');\\"></script><noscript></noscript><meta name=\\"head:count\\" content=\\"2\\">"')
     expect(htmlAttrs).toMatchInlineSnapshot('" data-head-attrs=\\"\\""')
   })
 

--- a/tests/encoding.test.ts
+++ b/tests/encoding.test.ts
@@ -91,7 +91,7 @@ describe('encoding', () => {
     )
   })
 
-  it.only('csr xss', () => {
+  it('csr xss', () => {
     const externalApiHeadData = {
       script: [
         {
@@ -109,7 +109,7 @@ describe('encoding', () => {
     head.updateDOM(dom.window.document, true)
 
     expect(dom.window.document.head.innerHTML).toMatchInlineSnapshot(
-      '"<script>console.alert(\\"xss\\")</script><meta name=\\"head:count\\" content=\\"1\\">"',
+      '"<script></script><meta name=\\"head:count\\" content=\\"1\\">"',
     )
   })
 })

--- a/tests/use-head-raw.test.ts
+++ b/tests/use-head-raw.test.ts
@@ -15,7 +15,7 @@ describe('use head raw', () => {
           },
           script: [
             {
-              children: 'console.log(2)',
+              innerHTML: 'console.log(2)',
               autofocus: true,
             },
           ],

--- a/tests/vue-ssr.test.tsx
+++ b/tests/vue-ssr.test.tsx
@@ -109,14 +109,14 @@ describe('vue ssr', () => {
       useHeadRaw({
         script: [
           {
-            children: 'console.log(\'hi\')',
+            innerHTML: 'console.log(\'hi\')',
           },
         ],
       })
     })
 
     expect(headResult.headTags).toMatchInlineSnapshot(
-      '"<script>console.log(&#39;hi&#39;)</script><meta name=\\"head:count\\" content=\\"1\\">"',
+      '"<script>console.log(\'hi\')</script><meta name=\\"head:count\\" content=\\"1\\">"',
     )
   })
 
@@ -125,17 +125,17 @@ describe('vue ssr', () => {
       script: [
         {
           key: 'my-script',
-          children: 'console.log(\'A\')',
+          innerHTML: 'console.log(\'A\')',
         },
         {
           key: 'my-script',
-          children: 'console.log(\'B\')',
+          innerHTML: 'console.log(\'B\')',
         },
       ],
     }))
 
     expect(headResult.headTags).toMatchInlineSnapshot(
-      '"<script>console.log(&#39;B&#39;)</script><meta name=\\"head:count\\" content=\\"1\\">"',
+      '"<script>console.log(\'B\')</script><meta name=\\"head:count\\" content=\\"1\\">"',
     )
   })
 })


### PR DESCRIPTION
## Issue

It is still possible to XSS when CSR using the `on` tag and `innerHTML`.

## Solution

Handle the validation in the core head tag resolving function, drop `innerHTML`