### PR TITLE
fix: use simpler API for tags

### DIFF
--- a/src/components.ts
+++ b/src/components.ts
@@ -17,8 +17,7 @@ const addVNodeToHeadObj = (node: VNode, obj: HeadObjectPlain) => {
 
   const props: HeadAttrs = node.props || {} as HeadAttrs
   if (node.children) {
-    const k = type === 'script' ? 'innerHTML' : 'textContent'
-    props[k] = Array.isArray(node.children)
+    props.children = Array.isArray(node.children)
       // @ts-expect-error untyped
       ? node.children[0]!.children
       : node.children
@@ -27,7 +26,7 @@ const addVNodeToHeadObj = (node: VNode, obj: HeadObjectPlain) => {
     (obj[type] as HeadAttrs[]).push(props)
 
   else if (type === 'title')
-    obj.title = props.textContent
+    obj.title = props.children
 
   else
     (obj[type] as HeadAttrs) = props

--- a/src/dom/create-element.ts
+++ b/src/dom/create-element.ts
@@ -12,15 +12,13 @@ export const createElement = (
       $el.setAttribute(k, v)
   })
 
-  if (tag._runtime.body === true) {
+  if (tag.options.body === true) {
     // set meta-body attribute to add the tag before </body>
     $el.setAttribute(BODY_TAG_ATTR_NAME, 'true')
   }
 
-  if (tag._runtime.raw && tag._runtime.innerHTML)
-    $el.innerHTML = tag._runtime.innerHTML
-  else
-    $el.textContent = tag._runtime.textContent || tag._runtime.children || ''
+  if (tag.children)
+    $el[tag.options.raw ? 'innerHTML' : 'textContent'] = tag.children
 
   return $el
 }

--- a/src/dom/update-dom.ts
+++ b/src/dom/update-dom.ts
@@ -24,8 +24,8 @@ export const updateDOM = async (head: HeadClient, previousTags: Set<string>, doc
   for (const tag of headTags) {
     switch (tag.tag) {
       case 'title':
-        if (typeof tag._runtime.textContent !== 'undefined')
-          document.title = tag._runtime.textContent
+        if (typeof tag.children !== 'undefined')
+          document.title = tag.children
         break
 
       case 'base':

--- a/src/dom/update-elements.ts
+++ b/src/dom/update-elements.ts
@@ -45,7 +45,7 @@ export const updateElements = (
   }
   let newElements = tags.map(tag => ({
     element: createElement(tag, document),
-    body: tag._runtime.body ?? false,
+    body: tag.options.body ?? false,
   }))
 
   newElements = newElements.filter((newEl) => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -25,7 +25,8 @@ export interface HeadTag {
   props: {
     [k: string]: any
   }
-  _runtime: HeadTagRuntime
+  children?: string
+  options: HeadTagRuntime
 }
 
 export interface HeadObjectApi<T extends MergeHead = {}> {

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -32,16 +32,18 @@ export interface HasTextContent {
    * Text content of the tag.
    *
    * @deprecated This can only be used with `useHeadRaw`.
+   *
+   * Alias for children
    */
   innerHTML?: string
   /**
    * Sets the textContent of an element.
-   *
-   * @deprecated Use `textContent` instead.
    */
   children?: string
   /**
    * Sets the textContent of an element. This will be HTML encoded.
+   *
+   * Alias for children
    */
   textContent?: string
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,8 +6,8 @@ import { resolveHeadEntry } from './ssr'
 
 export const sortTags = (aTag: HeadTag, bTag: HeadTag) => {
   const tagWeight = (tag: HeadTag) => {
-    if (tag._runtime.renderPriority)
-      return tag._runtime.renderPriority
+    if (tag.options.renderPriority)
+      return tag.options.renderPriority
 
     switch (tag.tag) {
       // This element must come before other elements with attribute values of URLs
@@ -30,7 +30,7 @@ export const sortTags = (aTag: HeadTag, bTag: HeadTag) => {
 }
 
 export const tagDedupeKey = <T extends HeadTag>(tag: T) => {
-  const { props, tag: tagName, _runtime } = tag
+  const { props, tag: tagName, options } = tag
   // must only be a single base so we always dedupe
   if (tagName === 'base' || tagName === 'title')
     return tagName
@@ -43,8 +43,8 @@ export const tagDedupeKey = <T extends HeadTag>(tag: T) => {
   if (props.charset)
     return 'charset'
 
-  if (_runtime.key)
-    return `${tagName}:${_runtime.key}`
+  if (options.key)
+    return `${tagName}:${options.key}`
 
   const name = ['id']
   if (tagName === 'meta')
@@ -55,7 +55,7 @@ export const tagDedupeKey = <T extends HeadTag>(tag: T) => {
       return `${tagName}:${n}:${props[n]}`
     }
   }
-  return tag._runtime.position!
+  return tag.options.position!
 }
 
 export function resolveUnrefHeadInput<T extends MergeHead = {}>(ref: UseHeadInput<T>): ResolvedUseHeadInput<T> {
@@ -91,27 +91,37 @@ const resolveTag = (name: TagKeys, input: Record<string, any>, e: HeadEntry): He
   const tag: HeadTag = {
     tag: name,
     props: [],
-    _runtime: {
+    options: {
       entryId: e.id,
       position: 0,
     },
   }
-  ;['hid', 'vmid'].forEach((key) => {
+  // dedupe keys
+  ;['hid', 'vmid', 'key'].forEach((key) => {
     if (input[key]) {
-      tag._runtime.key = input[key]
+      tag.options.key = input[key]
       delete input[key]
     }
   })
   // tag inherits options from useHead registration
-  tag._runtime = {
-    ...tag._runtime,
+  tag.options = {
+    ...tag.options,
     ...e.options,
   }
-  ;['body', 'renderPriority', 'key', 'children', 'innerHTML', 'textContent']
+  // set children key
+  ;['children', 'innerHTML', 'textContent']
+    .forEach((key) => {
+      if (typeof input[key] !== 'undefined') {
+        tag.children = input[key]
+        delete input[key]
+      }
+    })
+  // set options
+  ;['body', 'renderPriority']
     .forEach((key) => {
       if (typeof input[key] !== 'undefined') {
         // @ts-expect-error untyped
-        tag._runtime[key] = input[key]
+        tag.options[key] = input[key]
         delete input[key]
       }
     })
@@ -126,7 +136,7 @@ export const headInputToTags = (e: HeadEntry) => {
       return (Array.isArray(value) ? value : [value]).map((props) => {
         switch (key) {
           case 'title':
-            return resolveTag(key, { textContent: props }, e)
+            return resolveTag(key, { children: props }, e)
           case 'base':
           case 'meta':
           case 'link':
@@ -174,17 +184,17 @@ export const resolveHeadEntriesToTags = (entries: HeadEntry[]) => {
       // used to restore the order after deduping
       // a large number is needed otherwise the position will potentially duplicate (this support 10k tags)
       // ideally we'd use the total tag count but this is too hard to calculate with the current reactivity
-      tag._runtime.position = entryIndex * 10000 + tagIdx
+      tag.options.position = entryIndex * 10000 + tagIdx
 
       // resolve titles
       if (titleTemplate && tag.tag === 'title') {
-        tag._runtime.textContent = renderTitleTemplate(
+        tag.children = renderTitleTemplate(
           titleTemplate,
-          tag._runtime.textContent,
+          tag.children,
         )
       }
       // validate XSS vectors for non-raw input
-      if (!tag._runtime?.raw) {
+      if (!tag.options?.raw) {
         for (const k in tag.props) {
           if (k.startsWith('on') || k === 'innerHTML')
             delete tag.props[k]
@@ -197,6 +207,6 @@ export const resolveHeadEntriesToTags = (entries: HeadEntry[]) => {
   })
 
   return Object.values(deduping)
-    .sort((a, b) => a._runtime.position - b._runtime.position)
+    .sort((a, b) => a.options.position - b.options.position)
     .sort(sortTags)
 }

--- a/tests/basic.test.ts
+++ b/tests/basic.test.ts
@@ -68,7 +68,7 @@ describe('basic', () => {
     expect(resolveHeadEntriesToTags(head.headEntries)).toMatchInlineSnapshot(`
       [
         {
-          "_runtime": {
+          "options": {
             "entryId": 0,
             "position": 0,
           },

--- a/tests/e2e/vite-ssr/vite-ssr.test.ts
+++ b/tests/e2e/vite-ssr/vite-ssr.test.ts
@@ -59,11 +59,11 @@ describe('e2e: vite ssr', async () => {
       return resolveHeadEntriesToTags(head.headEntries)
     }
     expect(
-      (await getHeadTags()).find(t => t.tag === 'title')!._runtime.textContent,
+      (await getHeadTags()).find(t => t.tag === 'title')!.children,
     ).toMatchInlineSnapshot('"0 | @vueuse/head"')
     await page.click('button')
     expect(
-      (await getHeadTags()).find(t => t.tag === 'title')!._runtime.textContent,
+      (await getHeadTags()).find(t => t.tag === 'title')!.children,
     ).toMatchInlineSnapshot('"1 | @vueuse/head"')
   })
 

--- a/tests/encoding.test.ts
+++ b/tests/encoding.test.ts
@@ -19,7 +19,7 @@ describe('encoding', () => {
       ],
     })
     const { htmlAttrs, headTags } = await renderHeadToString(head)
-    expect(headTags).toMatchInlineSnapshot('"<script src=\\"javascript:console.log(\\\\\'xss\\\\\');\\"></script><noscript></noscript><meta name=\\"head:count\\" content=\\"2\\">"')
+    expect(headTags).toMatchInlineSnapshot('"<script src=\\"javascript:console.log(\\\\\'xss\\\\\');\\">alert(2)</script><noscript>&lt;iframe src=&quot;https://www.googletagmanager.com/ns.html?id=GTM-XXXXXXX&quot; height=&quot;0&quot; width=&quot;0&quot; style=&quot;display:none;visibility:hidden&quot;&gt;&lt;/iframe&gt;</noscript><meta name=\\"head:count\\" content=\\"2\\">"')
     expect(htmlAttrs).toMatchInlineSnapshot('" data-head-attrs=\\"\\""')
   })
 
@@ -102,7 +102,7 @@ describe('encoding', () => {
     head.updateDOM(dom.window.document, true)
 
     expect(dom.window.document.head.innerHTML).toMatchInlineSnapshot(
-      '"<script></script><meta name=\\"head:count\\" content=\\"1\\">"',
+      '"<script>console.alert(\\"xss\\")</script><meta name=\\"head:count\\" content=\\"1\\">"',
     )
   })
 })

--- a/tests/hook-tags-resolved.test.ts
+++ b/tests/hook-tags-resolved.test.ts
@@ -21,14 +21,14 @@ describe('hook tags resolved', () => {
 
     const tags = await hookTags
     expect(tags[0].tag).toEqual('title')
-    expect(tags[0]._runtime.textContent).toEqual('test')
+    expect(tags[0].children).toEqual('test')
     expect(tags).toMatchInlineSnapshot(`
       [
         {
-          "_runtime": {
+          "children": "test",
+          "options": {
             "entryId": 0,
             "position": 0,
-            "textContent": "test",
           },
           "props": {},
           "tag": "title",
@@ -61,10 +61,10 @@ describe('hook tags resolved', () => {
     expect(hooks[0].props.extra).toBeTruthy()
     expect(hooks[0]).toMatchInlineSnapshot(`
       {
-        "_runtime": {
+        "children": "test",
+        "options": {
           "entryId": 0,
           "position": 0,
-          "textContent": "test",
         },
         "props": {
           "extra": true,


### PR DESCRIPTION
## Issue

Overriding the tags using hooks is not friendly, modifying the property of `_runtime` is confusing if you just need to set inner content.

## Solution

Provide a root key of `children`, alias `textContent` and `innerHTML` to it. Rename `_runtime` to `options`.