### PR TITLE
fix: ensure tags props are immutable

### DIFF
--- a/examples/nuxt3/pages/issues/8181/index.vue
+++ b/examples/nuxt3/pages/issues/8181/index.vue
@@ -1,0 +1,18 @@
+<template>
+<div>
+  <div class="red">Index Page</div>
+  <NuxtLink to="/issues/8181/test">test</NuxtLink>
+  <br />
+  <NuxtLink to="/issues/8181">index</NuxtLink>
+</div>
+</template>
+
+<script setup lang="ts">
+useHead({
+  style: [
+    {
+      children: '.red { background-color: red }',
+    },
+  ],
+})
+</script>

--- a/examples/nuxt3/pages/issues/8181/test.vue
+++ b/examples/nuxt3/pages/issues/8181/test.vue
@@ -1,0 +1,19 @@
+<template>
+<div>
+  <div class="red">Test Page</div>
+  <NuxtLink to="/issues/8181/test">test</NuxtLink>
+  <br />
+  <NuxtLink to="/issues/8181">index</NuxtLink>
+</div>
+</template>
+
+<script setup lang="ts">
+useHead({
+  style: [
+    {
+      id: 'test',
+      children: '.red { background-color: red }',
+    },
+  ],
+});
+</script>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -98,6 +98,8 @@ export function resolveUnrefHeadInput<T extends MergeHead = {}>(ref: UseHeadInpu
 type HeadTagOptionKeys = (keyof HeadTagOptions)[]
 
 const resolveTag = (name: TagKeys, input: Record<string, any>, e: HeadEntry): HeadTag => {
+  // clone the input so we're not modifying source
+  input = { ...input }
   const tag: HeadTag = {
     tag: name,
     props: {},


### PR DESCRIPTION
## Issue

https://github.com/nuxt/framework/issues/8181#issuecomment-1279245823

## Description

Tag props are being passed by reference when turned to tags, when we clean up tag props, it's modifying the source props.