### PR TITLE
fix: ensure single pass of `htmlAttr` sanitization, fixes #142

### DIFF
--- a/src/ssr/index.ts
+++ b/src/ssr/index.ts
@@ -6,7 +6,6 @@ import {
   resolveHeadEntriesToTags,
   resolveUnrefHeadInput,
 } from '../index'
-import { sanitiseAttrName, sanitiseAttrValue } from '../encoding'
 
 export const propsToString = (props: HeadTag['props']) => {
   const handledAttributes = []
@@ -61,17 +60,14 @@ export const renderHeadToString = async <T extends MergeHead = {}>(head: HeadCli
     if (tag.options?.beforeTagRender)
       tag.options.beforeTagRender(tag)
 
-    if (tag.tag === 'title') { titleHtml = tagToString(tag) }
-    else if (tag.tag === 'htmlAttrs' || tag.tag === 'bodyAttrs') {
-      for (const k in tag.props) {
-        // always encode name to avoid html errors
-        attrs[tag.tag][sanitiseAttrName(k)] = sanitiseAttrValue(tag.props[k])
-      }
-    }
-    else if (tag.options?.body) { bodyHtml.push(tagToString(tag)) }
-    else {
+    if (tag.tag === 'title')
+      titleHtml = tagToString(tag)
+    else if (tag.tag === 'htmlAttrs' || tag.tag === 'bodyAttrs')
+      attrs[tag.tag] = { ...attrs[tag.tag], ...tag.props }
+    else if (tag.options?.body)
+      bodyHtml.push(tagToString(tag))
+    else
       headHtml.push(tagToString(tag))
-    }
   }
   headHtml.push(`<meta name="${HEAD_COUNT_KEY}" content="${headHtml.length}">`)
 

--- a/tests/encoding.test.ts
+++ b/tests/encoding.test.ts
@@ -20,7 +20,7 @@ describe('encoding', () => {
     })
     const { htmlAttrs, headTags } = await renderHeadToString(head)
     expect(headTags).toMatchInlineSnapshot('"<script src=\\"javascript:console.log(\'xss\');\\">alert(2)</script><noscript><iframe src=\\"https://www.googletagmanager.com/ns.html?id=GTM-XXXXXXX\\" height=\\"0\\" width=\\"0\\" style=\\"display:none;visibility:hidden\\"></iframe></noscript><meta name=\\"head:count\\" content=\\"2\\">"')
-    expect(htmlAttrs).toMatchInlineSnapshot('" onload=\\"console.log(\\\\\'executed\\\\\')\\" data-head-attrs=\\"onload\\""')
+    expect(htmlAttrs).toMatchInlineSnapshot('" onload=\\"console.log(\'executed\')\\" data-head-attrs=\\"onload\\""')
   })
 
   it('ssr jailbreak', async () => {

--- a/tests/vue-ssr.test.tsx
+++ b/tests/vue-ssr.test.tsx
@@ -164,4 +164,16 @@ describe('vue ssr', () => {
       '"<link href=\\"/\\"><link rel=\\"icon\\" type=\\"image/svg\\" href=\\"/favicon.svg\\"><meta name=\\"head:count\\" content=\\"2\\">"',
     )
   })
+
+  test('non-strings', async () => {
+    const headResult = await ssrRenderHeadToString(() => useHead({
+      htmlAttrs: {
+        'data-something': true,
+      },
+    }))
+
+    expect(headResult.htmlAttrs).toMatchInlineSnapshot(
+      '" data-something data-head-attrs=\\"data-something\\""',
+    )
+  })
 })


### PR DESCRIPTION
## Issue

See  #142

## Description

There was code left over as an artifact of the strict XSS prevention in < v.1 which made the input be sanitized multiple times for `htmlAttr` and `bodyAttr`. The issue with it is that the first pass wasn't casting to a string before sanitising.

We remove the first pass which should also reduce bundle size

