### PR TITLE
add vue 2.7 compatibility to Head component

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
   "dependencies": {
     "@vueuse/shared": "^9.3.1",
     "@zhead/schema": "^0.9.9",
-    "@zhead/schema-vue": "^0.9.9"
+    "@zhead/schema-vue": "^0.9.9",
+    "vue-demi": "*"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^0.27.0",


### PR DESCRIPTION
Fixes #146 .

Adds `vue-demi` as a dependency, but it was already (indirectly) required by `@vueuse/shared` so should not affect package size.

Open questions/concerns (perhaps to @harlan-zw ?):

* `@vueuse/shared` specifies `*` for `vue-demi`. I'm not sure if you want that or to specify an actual version like `^0.13.11`.
* Unit tests run under vue 3 so I'm not sure how to go about testing the changes for vue 2. It works for me through manual testing. The vue 3 tests are unaffected and still pass
* TS doesn't know about vue2 VNode types so it brings TS errors. Since only vue 3 is installed, unclear how that would be resolved so the affected lines are marked with `@ts-expect-error`