### PR TITLE
Vue 2.7 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ For integrating @vueuse/head with a framework.
 Register the Vue plugin:
 
 ```ts
+// Vue 3
 import { createApp } from "vue"
 import { createHead } from "@vueuse/head"
 
@@ -259,6 +260,20 @@ const head = createHead()
 app.use(head)
 
 app.mount("#app")
+```
+
+```ts
+// Vue 2
+import { createHead, HeadVuePlugin } from "@vueuse/head"
+
+Vue.use(HeadVuePlugin)
+const head = createHead()
+
+new Vue({
+  el: '#app',
+  // ...
+  head,
+})
 ```
 
 Manage `head` with the composition API `useHead` in your component:

--- a/src/index.ts
+++ b/src/index.ts
@@ -235,6 +235,8 @@ export const useHeadSafe = <T extends MergeHead = {}>(headObj: UseHeadInput<T>) 
   )
 }
 
+export { HeadVuePlugin } from './vue2-plugin'
+
 export * from './components'
 export * from './dom'
 export * from './ssr'

--- a/src/vue2-plugin.ts
+++ b/src/vue2-plugin.ts
@@ -1,0 +1,31 @@
+import type { Plugin } from 'vue-demi'
+import { PROVIDE_KEY } from './constants'
+
+export const HeadVuePlugin: Plugin = function (_Vue) {
+  _Vue.mixin({
+    beforeCreate() {
+      const options = this.$options
+      if (options.head) {
+        const origProvide = options.provide
+        options.provide = function () {
+          let origProvideResult
+          if (typeof origProvide === 'function')
+            origProvideResult = origProvide.call(this)
+          else
+            origProvideResult = origProvide || {}
+
+          return {
+            ...origProvideResult,
+            [PROVIDE_KEY]: options.head,
+          }
+        }
+
+        if (!this.$head)
+          this.$head = options.head
+      }
+      else if (!this.$head && options.parent && options.parent.$head) {
+        this.$head = options.parent.$head
+      }
+    },
+  })
+}


### PR DESCRIPTION
Fixed #141 .

Adds a Vue 2 plugin to mimic vue3's `provide` and `globalProperties`. Based loosely off how it's done in [Pinia](https://github.com/vuejs/pinia/blob/v2/packages/pinia/src/vue2-plugin.ts).

@harlan-zw this fixes the new other new init issues I was seeing in rc.12.