### PR TITLE
fix: dedupe `htmlAttrs` and `bodyAttrs` for csr

### DIFF
--- a/examples/nuxt3/pages/index.vue
+++ b/examples/nuxt3/pages/index.vue
@@ -8,6 +8,20 @@ const page = ref({
 })
 
 useHead({
+  bodyAttrs: {
+    style: 'background-color: red'
+  },
+})
+
+onMounted(() => {
+  useHead({
+    bodyAttrs: {
+      style: 'background-color: white'
+    },
+  })
+})
+
+useHead({
   title: computed(() => `${page.value.title} | Nuxt`),
   // note: this is still XSS vulnerable
   // script: [

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -40,7 +40,7 @@ export const sortTags = (aTag: HeadTag, bTag: HeadTag) => {
 export const tagDedupeKey = <T extends HeadTag>(tag: T) => {
   const { props, tag: tagName, options } = tag
   // must only be a single base so we always dedupe
-  if (tagName === 'base' || tagName === 'title' || tagName === 'titleTemplate')
+  if (['base', 'title', 'titleTemplate', 'bodyAttrs', 'htmlAttrs'].includes(tagName))
     return tagName
 
   // support only a single canonical

--- a/tests/e2e/nuxt3/nuxt.test.ts
+++ b/tests/e2e/nuxt3/nuxt.test.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from 'node:url'
-import { $fetch, setup } from '@nuxt/test-utils'
-import { load } from 'cheerio'
+import { createPage, setup } from '@nuxt/test-utils'
+import type { Page } from 'playwright'
 import { expectNoClientErrors } from './utils'
 
 await setup({
@@ -9,12 +9,68 @@ await setup({
   browser: true,
 })
 
+export async function queryHeadState(page: Page) {
+  const htmlAttrs = await page.evaluate('[...document.children[0].attributes].map(f => ({ name: f.name, value: f.value }))')
+  const bodyAttrs = await page.evaluate('[...document.querySelector(\'body\').attributes].map(f => ({ name: f.name, value: f.value }))')
+  const title = await page.title()
+  const $headCount = await page.evaluate('document.querySelector(\'meta[name="head:count"]\')')
+  let headTagCount = 0
+  let headTagIdx = 0
+  if ($headCount) {
+    headTagCount = Number.parseInt(await page.evaluate('document.querySelector(\'meta[name="head:count"]\')?.getAttribute(\'content\')'))
+    headTagIdx = Number.parseInt(await page.evaluate('[...document.head.children].indexOf(document.querySelector(\'meta[name="head:count"]\'))')) - 1
+  }
+  const bodyTags = await page.evaluate('document.querySelectorAll(\'[data-meta-body]\')')
+  let headTags = await page.evaluate('[...document.head.querySelectorAll(\'meta, script, link, noscript, style\').entries()].map(([k, v]) => v.outerHTML)')
+
+  // only the x before the head tag count
+  headTags = Object.entries(headTags).map(([key, value]) => {
+    const idx = Number.parseInt(key)
+    if (idx >= headTagIdx - headTagCount && idx < headTagIdx)
+      return value
+    return false
+  }).filter(Boolean)
+
+  return {
+    headTagCount,
+    title,
+    headTags,
+    bodyTags,
+    htmlAttrs,
+    bodyAttrs,
+  }
+}
+
 describe('e2e: nuxt 3', () => {
   it('basic', async () => {
-    const html = await $fetch('/')
-    const $ = load(html as string)
-    expect($('title').text()).equals('Home | Nuxt | Title Site')
-    expect($('meta[name="head:count"]').attr('content')).toMatch('2')
+    const page = await createPage('/', { })
+
+    await page.waitForTimeout(1000)
+
+    const ctx = await queryHeadState(page)
+
+    expect(ctx).toMatchInlineSnapshot(`
+      {
+        "bodyAttrs": [
+          {
+            "name": "style",
+            "value": "background-color: white",
+          },
+          {
+            "name": "data-head-attrs",
+            "value": "style",
+          },
+        ],
+        "bodyTags": {},
+        "headTagCount": 2,
+        "headTags": [
+          "<meta name=\\"description\\" content=\\"Home page description\\">",
+          "<meta property=\\"og:image\\" content=\\"https://nuxtjs.org/meta_400.png\\">",
+        ],
+        "htmlAttrs": [],
+        "title": "Home | Nuxt | Title Site",
+      }
+    `)
     await expectNoClientErrors('/')
   })
 })


### PR DESCRIPTION
## Issue

https://github.com/nuxt/framework/issues/8446

When client-side rendering it's taking the first entry instead of deduping them.