### PR TITLE
doc: readme renderHeadToString missing await

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ import { renderHeadToString } from "@vueuse/head"
 const appHTML = await renderToString(yourVueApp)
 
 // `head` is created from `createHead()`
-const { headTags, htmlAttrs, bodyAttrs, bodyTags } = renderHeadToString(head)
+const { headTags, htmlAttrs, bodyAttrs, bodyTags } = await renderHeadToString(head)
 
 const finalHTML = `
 <html${htmlAttrs}>


### PR DESCRIPTION
Just a small change to the readme, adding `await` to `renderHeadToString` , got a bit confusing switching from version `0.x` to `1.x` :) 